### PR TITLE
feat(theme): add is-authenticated middleware

### DIFF
--- a/packages/theme/middleware/is-authenticated.js
+++ b/packages/theme/middleware/is-authenticated.js
@@ -1,0 +1,15 @@
+export default (context) => {
+  const token = context.$cookies.get('spree-bearer-token');
+
+  if (token) {
+    const tokenExpiresAt = token.created_at + token.expires_in;
+    const currentTime = Date.now() / 1000;
+
+    if (currentTime < tokenExpiresAt) {
+      return;
+    }
+  }
+
+  context.app.router.push('/');
+  context.redirect('/');
+};


### PR DESCRIPTION
Implement is-authenticated.js middleware

## Description
This PR implements "is-authenticated" middleware, that's by default used by all /MyAccount pages. This protects access to them if the user doesn't have a current bearer token.

## How Has This Been Tested?
Manual tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
