### PR TITLE
add getLocale to api-client package

### DIFF
--- a/packages/api-client/src/api/internationalization/integration.ts
+++ b/packages/api-client/src/api/internationalization/integration.ts
@@ -1,9 +1,14 @@
 import { InternationalizationIntegration } from '../../types';
 
 const currencyCookieName = 'vsf-spree-currency';
+const localeCookieName = 'vsf-locale';
 
-export default function createInternationalizationIntegration(req, res): InternationalizationIntegration {
+export default function createInternationalizationIntegration(
+  req,
+  res
+): InternationalizationIntegration {
   const currentCurrency = req.cookies[currencyCookieName];
+  const currentLocale = req.cookies[localeCookieName];
 
   return {
     getCurrency: () => {
@@ -12,6 +17,14 @@ export default function createInternationalizationIntegration(req, res): Interna
       }
 
       return currentCurrency;
+    },
+
+    getLocale: () => {
+      if (currentLocale) {
+        res.cookie(localeCookieName, currentLocale);
+      }
+
+      return currentLocale;
     }
   };
 }

--- a/packages/api-client/src/types/index.ts
+++ b/packages/api-client/src/types/index.ts
@@ -35,10 +35,12 @@ export type AuthIntegrationContext = {
 
 export type InternationalizationIntegration = {
   getCurrency: () => string;
+  getLocale: () => string;
 }
 
 export type InternationalizationIntegrationContext = {
   getCurrency: () => Promise<string>;
+  getLocale: () => Promise<string>;
 }
 
 export type ApiConfig = {


### PR DESCRIPTION
there was no function to get current locale of vue storefront

## Description
i create some addition to have the ability to get current locale and use inside api-client package

## Motivation and Context
now you can get current locale of your storefront

## How Has This Been Tested?
manualy with console.log


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
