### PR TITLE
fix(#116): disable the 'continue' button when shipping is loading

### DIFF
--- a/packages/theme/components/Checkout/VsfShippingProvider.vue
+++ b/packages/theme/components/Checkout/VsfShippingProvider.vue
@@ -43,11 +43,8 @@ export default {
     const selectedShippingRates = ref({});
 
     const allShipmentsSelected = computed(() => {
-      if (!selectedShippingRates.value) {
-        return false;
-      }
-
-      return Object.values(selectedShippingRates.value)?.every(e => e !== null);
+      const shippingCodes = Object.values(selectedShippingRates.value);
+      return shippingCodes.length && shippingCodes.every(e => e !== null);
     });
 
     onMounted(async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Knowing it's not valid to have an empty list of shipping methods, we can establish whether values are loaded or not by checking the length of the values array. There are only 2 categories for length of the `allShipmentsSelected`: empty - not loaded, not empty - loaded. Hence, there's no need for checking if the promise has been resolved. Null checks are redundant since the initial state of the `selectedShippingRates` field is an empty object, which then is only modified by `reduce` method or the spread operator, in the current configuration they both don't return null values.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves #116

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, by debugging states of selectedShippingRates and allShipmentsSelected to establish the correctness of the solution.

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/18665370/157465575-3fec9713-ca8f-42f4-aac1-b67ce70ce674.mp4



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
