### PR TITLE
fix(#124): display total orders value based on user orders

### DIFF
--- a/packages/composables/src/getters/orderGetters.ts
+++ b/packages/composables/src/getters/orderGetters.ts
@@ -23,8 +23,7 @@ export const getItemPrice = (item: OrderItem): number => item?.price?.current ||
 
 export const getFormattedPrice = (price: number) => String(price);
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const getOrdersTotal = (orders: any): number => 1;
+export const getOrdersTotal = (orders: any): number => orders?.length || 0;
 
 const orderGetters: UserOrderGetters<Order, OrderItem> = {
   getDate,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With this commit, the counter of total user orders displays a proper value based on an actual length of orders.

## Description
<!--- Describe your changes in detail -->
Updated hard-coded value with an actual length of user orders, which defaults to `0` if the given `orders` object is null.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #124.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, by verifying backend response and frontend layer.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
