### PR TITLE
fix(#118): display order history accordingly to the backend response

### DIFF
--- a/packages/theme/pages/MyAccount/OrderHistory.vue
+++ b/packages/theme/pages/MyAccount/OrderHistory.vue
@@ -137,7 +137,7 @@ export default {
 
     return {
       tableHeaders,
-      orders: computed(() => orders ? orders.value.results : []),
+      orders,
       totalOrders: computed(() => orderGetters.getOrdersTotal(orders.value)),
       getStatusTextClass,
       orderGetters,

--- a/packages/theme/pages/MyAccount/OrderHistory.vue
+++ b/packages/theme/pages/MyAccount/OrderHistory.vue
@@ -1,0 +1,247 @@
+<template>
+  <SfTabs :open-tab="1">
+    <SfTab title="My orders">
+      <div v-if="currentOrder">
+        <SfButton class="sf-button--text all-orders" @click="currentOrder = null">All Orders</SfButton>
+        <div class="highlighted highlighted--total">
+          <SfProperty
+            name="Order ID"
+            :value="orderGetters.getId(currentOrder)"
+            class="sf-property--full-width property"
+          />
+          <SfProperty
+            name="Date"
+            :value="orderGetters.getDate(currentOrder)"
+            class="sf-property--full-width property"
+          />
+          <SfProperty
+            name="Status"
+            :value="orderGetters.getStatus(currentOrder)"
+            class="sf-property--full-width property"
+          />
+          <SfProperty
+            name="Total"
+            :value="$n(orderGetters.getPrice(currentOrder), 'currency')"
+            class="sf-property--full-width property"
+          />
+        </div>
+        <SfTable class="products">
+          <SfTableHeading>
+            <SfTableHeader class="products__name">{{ $t('Product') }}</SfTableHeader>
+            <SfTableHeader>{{ $t('Quantity') }}</SfTableHeader>
+            <SfTableHeader>{{ $t('Price') }}</SfTableHeader>
+          </SfTableHeading>
+          <SfTableRow v-for="(item, i) in orderGetters.getItems(currentOrder)" :key="i">
+            <SfTableData class="products__name">
+              <nuxt-link :to="'/p/'+orderGetters.getItemSku(item)+'/'+orderGetters.getItemSku(item)">
+                {{orderGetters.getItemName(item)}}
+              </nuxt-link>
+            </SfTableData>
+            <SfTableData>{{orderGetters.getItemQty(item)}}</SfTableData>
+            <SfTableData>{{$n(orderGetters.getItemPrice(item), 'currency')}}</SfTableData>
+          </SfTableRow>
+        </SfTable>
+      </div>
+      <div v-else>
+        <p class="message">
+          {{ $t('Details and status orders') }}
+        </p>
+        <div v-if="orders.length === 0" class="no-orders">
+          <p class="no-orders__title">{{ $t('You currently have no orders') }}</p>
+          <SfButton class="no-orders__button">{{ $t('Start shopping') }}</SfButton>
+        </div>
+        <SfTable v-else class="orders">
+          <SfTableHeading>
+            <SfTableHeader
+              v-for="tableHeader in tableHeaders"
+              :key="tableHeader"
+              >{{ tableHeader }}</SfTableHeader>
+            <SfTableHeader class="orders__element--right" />
+          </SfTableHeading>
+          <SfTableRow v-for="order in orders" :key="orderGetters.getId(order)">
+            <SfTableData v-e2e="'order-number'">{{ orderGetters.getId(order) }}</SfTableData>
+            <SfTableData>{{ orderGetters.getDate(order) }}</SfTableData>
+            <SfTableData>{{ $n(orderGetters.getPrice(order), 'currency') }}</SfTableData>
+            <SfTableData>
+              <span :class="getStatusTextClass(order)">{{ orderGetters.getStatus(order) }}</span>
+            </SfTableData>
+            <SfTableData class="orders__view orders__element--right">
+              <SfButton class="sf-button--text desktop-only" @click="currentOrder = order">
+                {{ $t('View details') }}
+              </SfButton>
+            </SfTableData>
+          </SfTableRow>
+        </SfTable>
+        <p>Total orders - {{ totalOrders }}</p>
+      </div>
+    </SfTab>
+    <SfTab title="Returns">
+      <p class="message">
+        This feature is not implemented yet! Please take a look at
+        <br />
+        <SfLink class="message__link" href="#">https://github.com/DivanteLtd/vue-storefront/issues</SfLink>
+        for our Roadmap!
+      </p>
+    </SfTab>
+  </SfTabs>
+</template>
+
+<script>
+import {
+  SfTabs,
+  SfTable,
+  SfButton,
+  SfProperty,
+  SfLink
+} from '@storefront-ui/vue';
+import { computed, ref } from '@nuxtjs/composition-api';
+import { useUserOrder, orderGetters } from '@vue-storefront/spree';
+import { AgnosticOrderStatus } from '@vue-storefront/core';
+import { onSSR } from '@vue-storefront/core';
+
+export default {
+  name: 'PersonalDetails',
+  components: {
+    SfTabs,
+    SfTable,
+    SfButton,
+    SfProperty,
+    SfLink
+  },
+  setup() {
+    const { orders, search } = useUserOrder();
+    const currentOrder = ref(null);
+
+    onSSR(async () => {
+      await search();
+    });
+
+    const tableHeaders = [
+      'Order ID',
+      'Payment date',
+      'Amount',
+      'Status'
+    ];
+
+    const getStatusTextClass = (order) => {
+      const status = orderGetters.getStatus(order);
+      switch (status) {
+        case AgnosticOrderStatus.Open:
+          return 'text-warning';
+        case AgnosticOrderStatus.Complete:
+          return 'text-success';
+        default:
+          return '';
+      }
+    };
+
+    return {
+      tableHeaders,
+      orders: computed(() => orders ? orders.value.results : []),
+      totalOrders: computed(() => orderGetters.getOrdersTotal(orders.value)),
+      getStatusTextClass,
+      orderGetters,
+      currentOrder
+    };
+  }
+};
+</script>
+
+<style lang='scss' scoped>
+.no-orders {
+  &__title {
+    margin: 0 0 var(--spacer-lg) 0;
+    font: var(--font-weight--normal) var(--font-size--base) / 1.6 var(--font-family--primary);
+  }
+  &__button {
+    --button-width: 100%;
+    @include for-desktop {
+      --button-width: 17,5rem;
+    }
+  }
+}
+.orders {
+  @include for-desktop {
+    &__element {
+      &--right {
+        --table-column-flex: 1;
+        text-align: right;
+      }
+    }
+  }
+}
+.all-orders {
+  --button-padding: var(--spacer-base) 0;
+}
+.message {
+  margin: 0 0 var(--spacer-xl) 0;
+  font: var(--font-weight--light) var(--font-size--base) / 1.6 var(--font-family--primary);
+  &__link {
+    color: var(--c-primary);
+    font-weight: var(--font-weight--medium);
+    font-family: var(--font-family--primary);
+    font-size: var(--font-size--base);
+    text-decoration: none;
+    &:hover {
+      color: var(--c-text);
+    }
+  }
+}
+.product {
+  &__properties {
+    margin: var(--spacer-xl) 0 0 0;
+  }
+  &__property,
+  &__action {
+    font-size: var(--font-size--sm);
+  }
+  &__action {
+    color: var(--c-gray-variant);
+    font-size: var(--font-size--sm);
+    margin: 0 0 var(--spacer-sm) 0;
+    &:last-child {
+      margin: 0;
+    }
+  }
+  &__qty {
+    color: var(--c-text);
+  }
+}
+.products {
+  --table-column-flex: 1;
+  &__name {
+    margin-right: var(--spacer-sm);
+    @include for-desktop {
+      --table-column-flex: 2;
+    }
+  }
+}
+.highlighted {
+  box-sizing: border-box;
+  width: 100%;
+  background-color: var(--c-light);
+  padding: var(--spacer-sm);
+  --property-value-font-size: var(--font-size--base);
+  --property-name-font-size: var(--font-size--base);
+  &:last-child {
+    margin-bottom: 0;
+  }
+  ::v-deep .sf-property__name {
+    white-space: nowrap;
+  }
+  ::v-deep .sf-property__value {
+    text-align: right;
+  }
+  &--total {
+    margin-bottom: var(--spacer-sm);
+  }
+  @include for-desktop {
+    padding: var(--spacer-xl);
+    --property-name-font-size: var(--font-size--lg);
+    --property-name-font-weight: var(--font-weight--medium);
+    --property-value-font-size: var(--font-size--lg);
+    --property-value-font-weight: var(--font-weight--semibold);
+  }
+}
+
+</style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With this commit, visiting the order history page while having no orders on the account, no longer results in seeing the error page.

## Description
<!--- Describe your changes in detail -->
The issue was found in the core library of the Vue Storefront; hence, creating our own version of the OrderHistory page was required in order to modify the computed value of orders. In the core library, orders were computed by retrieving the `results` field on the `orders.value` object. The problem was caused by the fact, `orders.value` is an array of orders, so it couldn't return the `results` field.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#118

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves #118.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, by testing different scenarios (user with no orders, user with 1 and more orders)\
## Screenshots (if appropriate):
![Screenshot 2022-03-10 at 18 30 20](https://user-images.githubusercontent.com/18665370/157721155-8e18b54d-c5e5-4bac-a328-34a7075070b2.png)
![Screenshot 2022-03-10 at 18 32 26](https://user-images.githubusercontent.com/18665370/157721430-cf699b75-df2d-476f-88ca-53ec0610797a.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
