### PR TITLE
fix(#109): pass Brand/Manufacturer filter properties correctly

### DIFF
--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -15,7 +15,14 @@ export default async function getProducts({ client, config }: ApiContext, params
     }
 
     const optionValueIds = optionTypeFilters?.map(filter => filter.optionValueId);
-    const properties = productPropertyFilters?.reduce((result, filter) => ({ ...result, [filter.productPropertyName]: filter.productPropertyValue }), {});
+    const properties = productPropertyFilters?.reduce((result, filter) => {
+      const separator = ',';
+      const resultedValues = result[filter.productPropertyName]?.split(separator) || [];
+      return {
+        ...result,
+        [filter.productPropertyName]: [...resultedValues, filter.productPropertyValue].join(separator)
+      };
+    }, {});
 
     const result = await client.products.list(
       undefined,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Reducing the array of filter objects, by assigning each filter value to its relative key caused overriding the key's value and calling the API with only the most recently applied one.

## Description
<!--- Describe your changes in detail -->
With this commit, values are stringified, separated by a comma, and assigned to their relative key. In the properties object.

Having 
```
optionTypeFilters = [
    {productPropertyName: 'brand', productPropertyValue: 'alpha'},
    {productPropertyName: 'brand', productPropertyValue: 'beta'}
]
```
Before:
```properties = {brand: 'beta'}```
Now:
```properties =  {brand: 'alpha,beta'}```

The same applies to manufacturers.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#109

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves #109  - Selecting multiple filters for Brand and Manufacturer caused applying only the most recently selected one.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, by debugging state of properties and verifying response send to the API.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
