### PR TITLE
fix(#136): avoid layout shifts of the product info panel

### DIFF
--- a/packages/theme/pages/Product.vue
+++ b/packages/theme/pages/Product.vue
@@ -298,6 +298,7 @@ export default {
     display: flex;
   }
   &__info {
+    width: 100%;
     margin: var(--spacer-sm) auto;
     @include for-desktop {
       max-width: 32.625rem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With this commit, switching between tabs in the Product Info panel no longer leads to layout shifts.

## Description
<!--- Describe your changes in detail -->
Setting a fixed width of 100% to the Product info container always maintains the maximal possible width. Having a maximal possible width of the container won't lead to layout shifts if the content inside gets shorter.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#136

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Layout shifts lead to poor UX quality.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/18665370/158425443-17cac647-e9a8-4815-b98d-f45287abe4d9.mov


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
