### PR TITLE
feat: add an option to use the same address for billing

### DIFF
--- a/packages/theme/pages/Checkout/Shipping.vue
+++ b/packages/theme/pages/Checkout/Shipping.vue
@@ -211,14 +211,14 @@
         <div class="form__action">
           <SfCheckbox
             name="shippingToBilling"
-            label="Copy shipment details to billing"
+            label="Use the same details for billing"
             hintMessage=""
             :required="false"
             infoMessage=""
             errorMessage=""
             valid
             :disabled="false"
-            v-model="isShipmentToBillingSelected"
+            v-model="isCopyToBillingSelected"
           />
         </div>
         <div class="form__action">
@@ -286,13 +286,13 @@ export default {
     const router = useRouter();
     const isFormSubmitted = ref(false);
     const isSaveAddressSelected = ref(false);
-    const isShipmentToBillingSelected = ref(true);
+    const isCopyToBillingSelected = ref(true);
     const { countries, states, load: loadCountries, loadStates } = useCountry();
     const { shipping: checkoutShippingAddress, load, save, loading } = useShipping();
     const { shipping: savedAddresses, load: loadSavedAddresses, addAddress } = useUserShipping();
     const { isAuthenticated } = useUser();
     const { $spree } = useVSFContext();
-    const biling = useBilling();
+    const billing = useBilling();
 
     const selectedSavedAddressId = ref(undefined);
     const form = ref({
@@ -327,7 +327,9 @@ export default {
         : form.value;
 
       await save({ shippingDetails: shippingAddress });
-      if (isShipmentToBillingSelected.value) await biling.save({ billingDetails: shippingAddress });
+      if (isCopyToBillingSelected.value) {
+        await billing.save({ billingDetails: shippingAddress });
+      }
 
       if (isSaveAddressSelected.value) {
         await addAddress({ address: shippingAddress });
@@ -401,7 +403,7 @@ export default {
       selectedSavedAddressId,
       checkoutShippingAddress,
       handleFormSubmit,
-      isShipmentToBillingSelected
+      isCopyToBillingSelected
     };
   }
 };

--- a/packages/theme/pages/Checkout/Shipping.vue
+++ b/packages/theme/pages/Checkout/Shipping.vue
@@ -209,6 +209,19 @@
       </div>
       <div class="form">
         <div class="form__action">
+          <SfCheckbox
+            name="shippingToBilling"
+            label="Copy shipment details to billing"
+            hintMessage=""
+            :required="false"
+            infoMessage=""
+            errorMessage=""
+            valid
+            :disabled="false"
+            v-model="isShipmentToBillingSelected"
+          />
+        </div>
+        <div class="form__action">
           <SfButton
             v-if="!isFormSubmitted"
             :disabled="loading"
@@ -237,7 +250,7 @@ import {
 } from '@storefront-ui/vue';
 import { ref, watch, computed, onMounted, useRouter } from '@nuxtjs/composition-api';
 import { onSSR, useVSFContext } from '@vue-storefront/core';
-import { useShipping, useCountry, useUser, useUserShipping } from '@vue-storefront/spree';
+import { useBilling, useShipping, useCountry, useUser, useUserShipping } from '@vue-storefront/spree';
 import { required, min, digits } from 'vee-validate/dist/rules';
 import { ValidationProvider, ValidationObserver, extend } from 'vee-validate';
 import AddressPicker from '~/components/Checkout/AddressPicker';
@@ -273,11 +286,13 @@ export default {
     const router = useRouter();
     const isFormSubmitted = ref(false);
     const isSaveAddressSelected = ref(false);
+    const isShipmentToBillingSelected = ref(true);
     const { countries, states, load: loadCountries, loadStates } = useCountry();
     const { shipping: checkoutShippingAddress, load, save, loading } = useShipping();
     const { shipping: savedAddresses, load: loadSavedAddresses, addAddress } = useUserShipping();
     const { isAuthenticated } = useUser();
     const { $spree } = useVSFContext();
+    const biling = useBilling();
 
     const selectedSavedAddressId = ref(undefined);
     const form = ref({
@@ -312,6 +327,7 @@ export default {
         : form.value;
 
       await save({ shippingDetails: shippingAddress });
+      if (isShipmentToBillingSelected.value) await biling.save({ billingDetails: shippingAddress });
 
       if (isSaveAddressSelected.value) {
         await addAddress({ address: shippingAddress });
@@ -384,7 +400,8 @@ export default {
       savedAddresses,
       selectedSavedAddressId,
       checkoutShippingAddress,
-      handleFormSubmit
+      handleFormSubmit,
+      isShipmentToBillingSelected
     };
   }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add an option to use the same address for billing instead of tying it twice
## Description
<!--- Describe your changes in detail -->
added checkbox that allows user to pass the provided shipment data to billing address so the person using site will not have to type the same details twice
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#132
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
