### PR TITLE
fix: fixed missing menu and refactored it to show all categories

### DIFF
--- a/packages/theme/components/AppHeader.vue
+++ b/packages/theme/components/AppHeader.vue
@@ -107,7 +107,7 @@
 import { SfHeader, SfImage, SfIcon, SfButton, SfBadge, SfSearchBar, SfOverlay } from '@storefront-ui/vue';
 import { useUiState } from '~/composables';
 import { useCart, useFacet, useUser, cartGetters } from '@vue-storefront/spree';
-import { computed, ref, watch, onBeforeUnmount, useRouter } from '@nuxtjs/composition-api';
+import { computed, ref, watch, onBeforeUnmount, useRouter, onUpdated } from '@nuxtjs/composition-api';
 import { useUiHelpers } from '~/composables';
 import LocaleSelector from './LocaleSelector';
 import SearchResults from '~/components/SearchResults';
@@ -198,6 +198,10 @@ export default {
     });
 
     const removeSearchResults = () => {};
+
+    onUpdated(() => {
+      mapMobileObserver();
+    });
 
     onBeforeUnmount(() => {
       unMapMobileObserver();

--- a/packages/theme/components/HeaderNavigation.vue
+++ b/packages/theme/components/HeaderNavigation.vue
@@ -9,7 +9,7 @@
       :link="localePath(`/c/categories/${category}`)"
     />
   </div>
-  <SfModal v-else-if="isCategoryTreeAvailable()" :visible="isMobileMenuOpen">
+  <SfModal v-else-if="isCategoryTreeAvailable" :visible="isMobileMenuOpen">
     <SfAccordion open="" :multiple="false" transition="" showChevron>
       <SfAccordionItem
         v-for="(cat, i) in categoryTree && categoryTree.items"

--- a/packages/theme/components/HeaderNavigation.vue
+++ b/packages/theme/components/HeaderNavigation.vue
@@ -85,9 +85,7 @@ export default {
     const categoryTree = computed(() => facetGetters.getCategoryTree(result.value));
     const categories = ['women', 'men'];
 
-    const isCategoryTreeEmpty = () => {
-      return !(typeof categoryTree.value.items === 'undefined');
-    };
+    const isCategoryTreeAvailable = computed(() => categoryTree.value?.items?.length > 0);
 
     return {
       isCategoryTreeEmpty,

--- a/packages/theme/components/HeaderNavigation.vue
+++ b/packages/theme/components/HeaderNavigation.vue
@@ -9,7 +9,7 @@
       :link="localePath(`/c/categories/${category}`)"
     />
   </div>
-  <SfModal v-else-if="isCategoryTreeEmpty()" :visible="isMobileMenuOpen">
+  <SfModal v-else-if="isCategoryTreeAvailable()" :visible="isMobileMenuOpen">
     <SfAccordion open="" :multiple="false" transition="" showChevron>
       <SfAccordionItem
         v-for="(cat, i) in categoryTree && categoryTree.items"
@@ -88,7 +88,7 @@ export default {
     const isCategoryTreeAvailable = computed(() => categoryTree.value?.items?.length > 0);
 
     return {
-      isCategoryTreeEmpty,
+      isCategoryTreeAvailable,
       categoryTree,
       categories,
       isMobileMenuOpen,

--- a/packages/theme/components/HeaderNavigation.vue
+++ b/packages/theme/components/HeaderNavigation.vue
@@ -9,6 +9,37 @@
       :link="localePath(`/c/categories/${category}`)"
     />
   </div>
+  <SfModal v-else-if="isCategoryTreeEmpty()" :visible="isMobileMenuOpen">
+    <SfAccordion open="" :multiple="false" transition="" showChevron>
+      <SfAccordionItem
+        v-for="(cat, i) in categoryTree && categoryTree.items"
+        :key="i"
+        class="nav-item"
+        :header="cat.label"
+      >
+        <SfList>
+          <SfListItem>
+            <SfMenuItem
+              label="All"
+              class="sf-header-navigation-item__menu-item"
+              :link="localePath(`/c/categories/${cat.label.replace(/\s+/g, '-').toLowerCase()}`)"
+              @click.native="toggleMobileMenu"
+            />
+          </SfListItem>
+          <SfListItem
+            v-for="(subCat, j) in cat.items"
+            :key="j">
+            <SfMenuItem
+              :label="subCat.label"
+              class="sf-header-navigation-item__menu-item"
+              :link="localePath(`/c/categories/${cat.label.replace(/\s+/g, '-').toLowerCase()}/${subCat.label.replace(/\s+/g, '-').toLowerCase()}`)"
+              @click.native="toggleMobileMenu"
+            />
+          </SfListItem>
+        </SfList>
+      </SfAccordionItem>
+    </SfAccordion>
+  </SfModal>
   <SfModal v-else :visible="isMobileMenuOpen">
     <SfHeaderNavigationItem
       v-for="(category, index) in categories"
@@ -29,14 +60,18 @@
 </template>
 
 <script>
-import { SfMenuItem, SfModal } from '@storefront-ui/vue';
+import { SfMenuItem, SfModal, SfAccordion, SfList } from '@storefront-ui/vue';
 import { useUiState } from '~/composables';
+import { computed } from '@nuxtjs/composition-api';
+import { facetGetters, useFacet } from '@vue-storefront/spree';
 
 export default {
   name: 'HeaderNavigation',
   components: {
     SfMenuItem,
-    SfModal
+    SfModal,
+    SfAccordion,
+    SfList
   },
   props: {
     isMobile: {
@@ -45,10 +80,18 @@ export default {
     }
   },
   setup() {
+    const { result } = useFacet();
     const { isMobileMenuOpen, toggleMobileMenu } = useUiState();
+    const categoryTree = computed(() => facetGetters.getCategoryTree(result.value));
     const categories = ['women', 'men'];
 
+    const isCategoryTreeEmpty = () => {
+      return !(typeof categoryTree.value.items === 'undefined');
+    };
+
     return {
+      isCategoryTreeEmpty,
+      categoryTree,
       categories,
       isMobileMenuOpen,
       toggleMobileMenu

--- a/packages/theme/components/HeaderNavigation.vue
+++ b/packages/theme/components/HeaderNavigation.vue
@@ -22,7 +22,7 @@
             <SfMenuItem
               label="All"
               class="sf-header-navigation-item__menu-item"
-              :link="localePath(`/c/categories/${cat.label.replace(/\s+/g, '-').toLowerCase()}`)"
+              :link="localePath(`/c/${cat.slug}`)"
               @click.native="toggleMobileMenu"
             />
           </SfListItem>
@@ -32,7 +32,7 @@
             <SfMenuItem
               :label="subCat.label"
               class="sf-header-navigation-item__menu-item"
-              :link="localePath(`/c/categories/${cat.label.replace(/\s+/g, '-').toLowerCase()}/${subCat.label.replace(/\s+/g, '-').toLowerCase()}`)"
+              :link="localePath(`/c/${subCat.slug}`)"
               @click.native="toggleMobileMenu"
             />
           </SfListItem>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed disappearing menu and refactored it to be show all categories
## Description
<!--- Describe your changes in detail -->
On mobile version:
After a few click on the menu observers were closed one by one and it did not show up anymore. Added a function that changes the amount of observers to nullify disappearing ones. Also refactored a bit menu shows in products tab so it shows all the possible categories 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#121
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Menu does not work properly without those changes and it could be confusing to the user.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually by checking observers
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
