### PR TITLE
fix(#158): load saved addresses on successful authentication during checkout

### DIFF
--- a/packages/theme/pages/Checkout/Billing.vue
+++ b/packages/theme/pages/Checkout/Billing.vue
@@ -294,10 +294,6 @@ export default {
       await loadSavedAddresses();
       await loadCountries();
 
-      if (form.value.country) {
-        await loadStates(form.value.country);
-      }
-
       if (checkoutBillingAddress.value) {
         form.value = _.omit(checkoutBillingAddress.value, ['_id']);
       }
@@ -310,10 +306,6 @@ export default {
       await loadSavedAddresses();
       await loadCountries();
 
-      if (form.value.country) {
-        await loadStates(form.value.country);
-      }
-
       if (checkoutBillingAddress.value) {
         form.value = _.omit(checkoutBillingAddress.value, ['_id']);
       }
@@ -321,11 +313,24 @@ export default {
       populateSelectedAddressId();
     });
 
-    watch(() => form.value.country, async (newValue, oldValue) => {
-      if (newValue !== oldValue) {
-        form.value.state = null;
-        await loadStates(newValue);
+    watch(() => form.value.country, async (newCountryValue, oldCountryValue) => {
+      if (newCountryValue === oldCountryValue) return;
+      form.value.state = null;
+      await loadStates(newCountryValue);
+    }, {
+      immediate: true
+    });
+
+    watch(() => isAuthenticated.value, async (isAuthenticatedNow) => {
+      if (!isAuthenticatedNow) return;
+      await load();
+      await loadSavedAddresses();
+
+      if (checkoutBillingAddress.value) {
+        form.value = _.omit({...form.value, ...checkoutBillingAddress.value}, ['_id']);
       }
+
+      populateSelectedAddressId();
     });
 
     return {

--- a/packages/theme/pages/Checkout/Shipping.vue
+++ b/packages/theme/pages/Checkout/Shipping.vue
@@ -327,10 +327,6 @@ export default {
       await loadSavedAddresses();
       await loadCountries();
 
-      if (form.value.country) {
-        await loadStates(form.value.country);
-      }
-
       if (checkoutShippingAddress.value) {
         form.value = _.omit(checkoutShippingAddress.value, ['_id']);
       }
@@ -343,10 +339,6 @@ export default {
       await loadSavedAddresses();
       await loadCountries();
 
-      if (form.value.country) {
-        await loadStates(form.value.country);
-      }
-
       if (checkoutShippingAddress.value) {
         form.value = _.omit(checkoutShippingAddress.value, ['_id']);
       }
@@ -354,11 +346,24 @@ export default {
       populateSelectedAddressId();
     });
 
-    watch(() => form.value.country, async (newValue, oldValue) => {
-      if (newValue !== oldValue) {
-        form.value.state = null;
-        await loadStates(newValue);
+    watch(() => form.value.country, async (newCountryValue, oldCountryValue) => {
+      if (newCountryValue === oldCountryValue) return;
+      form.value.state = null;
+      await loadStates(newCountryValue);
+    }, {
+      immediate: true
+    });
+
+    watch(() => isAuthenticated.value, async (isAuthenticatedNow) => {
+      if (!isAuthenticatedNow) return;
+      await load();
+      await loadSavedAddresses();
+
+      if (checkoutShippingAddress.value) {
+        form.value = _.omit({...form.value, ...checkoutShippingAddress.value}, ['_id']);
       }
+
+      populateSelectedAddressId();
     });
 
     return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With this PR, when a user logs in during the checkout process, the saved addresses will be loaded.

## Description
<!--- Describe your changes in detail -->
I've added a watcher for `isAuthenticated` value, which loads necessary data if a user gets authenticated on the shipping/billing page. The watcher updates already filled form values with checkoutShippingAddress/checkoutBillingAddress, so that the user won't lose provided data (Imagine a case, where a user filled some of the form fields and decided to log in afterward; we don't want to lose that data).

I've also removed reused code in lifecycle methods for form.value.country and transformed already existing watcher into the [eager watcher](https://vuejs.org/guide/essentials/watchers.html#eager-watchers) where I've implemented removed code.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#158 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A user couldn't get their saved addresses during the checkout process if they decided to log-in in the meantime.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
https://user-images.githubusercontent.com/18665370/159030333-8c55f1f9-4e8b-4a36-988d-b67c1d70e2f5.mov

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
