### PR TITLE
fix(#165): removed an option to change shipping details after shipment 

### DIFF
--- a/packages/theme/components/Checkout/AddressPicker.vue
+++ b/packages/theme/components/Checkout/AddressPicker.vue
@@ -2,7 +2,7 @@
   <SfAddressPicker
     class="address-picker"
     v-if="addresses && addresses.length > 0"
-    v-bind:class="{'disable-input': isFormSubmitted}"
+    :class="{'disable-input': isFormSubmitted}"
     :selected="selectedAddressId"
     @change="onSelectAddress"
   >
@@ -40,12 +40,15 @@ export default {
     value: {
       type: String,
       default: ''
+    },
+    isFormSubmitted: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
     return {
       selectedAddressId: this.value,
-      isFormSubmitted: this.$attrs.isFormSubmitted
     };
   },
   methods: {

--- a/packages/theme/components/Checkout/AddressPicker.vue
+++ b/packages/theme/components/Checkout/AddressPicker.vue
@@ -48,7 +48,7 @@ export default {
   },
   data() {
     return {
-      selectedAddressId: this.value,
+      selectedAddressId: this.value
     };
   },
   methods: {

--- a/packages/theme/components/Checkout/AddressPicker.vue
+++ b/packages/theme/components/Checkout/AddressPicker.vue
@@ -2,6 +2,7 @@
   <SfAddressPicker
     class="address-picker"
     v-if="addresses && addresses.length > 0"
+    v-bind:class="{'disable-input': isFormSubmitted}"
     :selected="selectedAddressId"
     @change="onSelectAddress"
   >
@@ -43,7 +44,8 @@ export default {
   },
   data() {
     return {
-      selectedAddressId: this.value
+      selectedAddressId: this.value,
+      isFormSubmitted: this.$attrs.isFormSubmitted
     };
   },
   methods: {
@@ -68,5 +70,9 @@ export default {
   flex-wrap: wrap;
   gap: var(--spacer-xs);
   margin-bottom: var(--spacer-xs);
+}
+.disable-input {
+  --input-color: var(--c-text-disabled);
+  -webkit-text-fill-color: var(--c-text-disabled);
 }
 </style>

--- a/packages/theme/components/Checkout/VsfShippingProvider.vue
+++ b/packages/theme/components/Checkout/VsfShippingProvider.vue
@@ -12,15 +12,26 @@
     <SfButton
       v-e2e="'continue-to-billing'"
       :disabled="!allShipmentsSelected"
+      class="checkout__button"
       type="button"
       @click="save"
     >
       {{ $t('Continue to billing') }}
     </SfButton>
+
+    <SfButton
+      v-e2e="'get-back-to-shipping'"
+      class="checkout__button"
+      type="button"
+      @click="getBackToShippingDetails()"
+    >
+      {{ $t('Change shipping details') }}
+    </SfButton>
   </div>
 </template>
 
 <script>
+
 import { SfButton } from '@storefront-ui/vue';
 import { computed, ref, onMounted } from '@nuxtjs/composition-api';
 import { Logger, useVSFContext } from '@vue-storefront/core';
@@ -39,6 +50,7 @@ export default {
     const { $spree } = useVSFContext();
     const { setCart } = useCart();
     const { state: shipments, save: saveShipments, load: loadShipments } = useShippingProvider();
+    const getBackToShippingDetails = () => location.reload();
 
     const selectedShippingRates = ref({});
 
@@ -72,7 +84,8 @@ export default {
       shipments,
       allShipmentsSelected,
       selectShippingRate,
-      save
+      save,
+      getBackToShippingDetails
     };
   }
 };
@@ -81,5 +94,9 @@ export default {
 <style lang="scss" scoped>
 .vsf-shipping-provider__rate-picker {
   margin-bottom: var(--spacer-base);
+}
+.checkout__button{
+  --button-width: 50%;
+  margin: var(--spacer-sm) 0;
 }
 </style>

--- a/packages/theme/components/Checkout/VsfShippingProvider.vue
+++ b/packages/theme/components/Checkout/VsfShippingProvider.vue
@@ -50,7 +50,7 @@ export default {
     const { $spree } = useVSFContext();
     const { setCart } = useCart();
     const { state: shipments, save: saveShipments, load: loadShipments } = useShippingProvider();
-    const getBackToShippingDetails = () => location.reload();
+    const getBackToShippingDetails = () => emit('back');
 
     const selectedShippingRates = ref({});
 

--- a/packages/theme/components/Checkout/VsfShippingProvider.vue
+++ b/packages/theme/components/Checkout/VsfShippingProvider.vue
@@ -8,25 +8,25 @@
       class="vsf-shipping-provider__rate-picker"
       @change="shippingRateId => selectShippingRate(shipment.id, shippingRateId)"
     />
+      <div class="form__action">
+        <SfButton
+          v-e2e="'get-back-to-shipping'"
+          class="sf-button color-secondary checkout__button"
+          type="button"
+          @click="getBackToShippingDetails()"
+        >
+          {{ $t('Change shipping details') }}
+        </SfButton>
 
-    <SfButton
-      v-e2e="'continue-to-billing'"
-      :disabled="!allShipmentsSelected"
-      class="checkout__button"
-      type="button"
-      @click="save"
-    >
-      {{ $t('Continue to billing') }}
-    </SfButton>
-
-    <SfButton
-      v-e2e="'get-back-to-shipping'"
-      class="checkout__button"
-      type="button"
-      @click="getBackToShippingDetails()"
-    >
-      {{ $t('Change shipping details') }}
-    </SfButton>
+        <SfButton
+          v-e2e="'continue-to-billing'"
+          class="checkout__button"
+          type="button"
+          @click="save"
+        >
+          {{ $t('Continue to billing') }}
+        </SfButton>
+      </div>
   </div>
 </template>
 
@@ -95,8 +95,22 @@ export default {
 .vsf-shipping-provider__rate-picker {
   margin-bottom: var(--spacer-base);
 }
+.form {
+  &__action {
+    @include for-desktop {
+      flex: 0 0 100%;
+      display: flex;
+    }
+  }
+}
+
 .checkout__button{
-  --button-width: 50%;
-  margin: var(--spacer-sm) 0;
+  margin: var(--spacer-xl) 0 var(--spacer-sm);
+  &:hover {
+    color:  white;
+  }
+  @include for-desktop {
+    margin: 0 var(--spacer-xl) 0 0;
+  }
 }
 </style>

--- a/packages/theme/pages/Checkout/Shipping.vue
+++ b/packages/theme/pages/Checkout/Shipping.vue
@@ -235,6 +235,7 @@
       <VsfShippingProvider
         v-if="isFormSubmitted"
         @submit="router.push(localePath({ name: 'billing' }))"
+        @back="() => isFormSubmitted = !isFormSubmitted"
       />
     </form>
   </ValidationObserver>
@@ -403,7 +404,7 @@ export default {
       selectedSavedAddressId,
       checkoutShippingAddress,
       handleFormSubmit,
-      isCopyToBillingSelected
+      isCopyToBillingSelected,
     };
   }
 };

--- a/packages/theme/pages/Checkout/Shipping.vue
+++ b/packages/theme/pages/Checkout/Shipping.vue
@@ -27,7 +27,7 @@
         >
           <SfInput
             v-on:click="getBackToShippingDetails()"
-            v-bind:class="{'disbale-input': isFormSubmitted}"
+            :class="{'disable-input': isFormSubmitted}"
             v-model="form.email"
             label="Email"
             name="email"
@@ -44,7 +44,7 @@
         >
           <SfInput
             v-on:click="getBackToShippingDetails()"
-            v-bind:class="{'disable-input': isFormSubmitted}"
+            :class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-firstName'"
             v-model="form.firstName"
             label="First name"
@@ -63,7 +63,7 @@
         >
           <SfInput
             v-on:click="getBackToShippingDetails()"
-            v-bind:class="{'disable-input': isFormSubmitted}"
+            :class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-lastName'"
             v-model="form.lastName"
             label="Last name"
@@ -82,7 +82,7 @@
         >
           <SfInput
             v-on:click="getBackToShippingDetails()"
-            v-bind:class="{'disable-input': isFormSubmitted}"
+            :class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-streetName'"
             v-model="form.addressLine1"
             label="Street name"
@@ -95,7 +95,7 @@
         </ValidationProvider>
         <SfInput
           v-on:click="getBackToShippingDetails()"
-          v-bind:class="{'disable-input': isFormSubmitted}"
+          :class="{'disable-input': isFormSubmitted}"
           v-e2e="'shipping-apartment'"
           v-model="form.addressLine2"
           label="House/Apartment number"
@@ -110,7 +110,7 @@
         >
           <SfInput
             v-on:click="getBackToShippingDetails()"
-            v-bind:class="{'disable-input': isFormSubmitted}"
+            :class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-city'"
             v-model="form.city"
             label="City"
@@ -129,7 +129,7 @@
           slim
         >
           <SfSelect
-            v-bind:class="{'disable-dropdown': isFormSubmitted}"
+            :class="{'disable-dropdown': isFormSubmitted}"
             data-cy="shipping-details-input_state"
             class="form__element form form__select sf-select--underlined"
             v-model="form.state"
@@ -156,7 +156,7 @@
           slim
         >
           <SfSelect
-            v-bind:class="{'disable-dropdown': isFormSubmitted}"
+            :class="{'disable-dropdown': isFormSubmitted}"
             v-e2e="'shipping-country'"
             v-model="form.country"
             label="Country"
@@ -184,7 +184,7 @@
         >
           <SfInput
             v-on:click="getBackToShippingDetails()"
-            v-bind:class="{'disable-input': isFormSubmitted}"
+            :class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-zipcode'"
             v-model="form.postalCode"
             label="Zip-code"
@@ -203,7 +203,7 @@
         >
           <SfInput
             v-on:click="getBackToShippingDetails()"
-            v-bind:class="{'disable-input': isFormSubmitted}"
+            :class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-phone'"
             v-model="form.phone"
             label="Phone number"

--- a/packages/theme/pages/Checkout/Shipping.vue
+++ b/packages/theme/pages/Checkout/Shipping.vue
@@ -7,10 +7,14 @@
       class="sf-heading--left sf-heading--no-underline title"
     />
     <AddressPicker
-      v-if="isAuthenticated && savedAddresses && !isFormSubmitted"
+      v-if="isAuthenticated && savedAddresses"
       v-model="selectedSavedAddressId"
+      :key="isFormSubmitted"
       :addresses="savedAddresses.addresses"
       :saved-address="checkoutShippingAddress"
+      :isFormSubmitted="isFormSubmitted"
+      @input="getBackToShippingDetails()"
+
     />
     <form @submit.prevent="handleSubmit(handleFormSubmit)">
       <div v-if="!selectedSavedAddressId" class="form">
@@ -22,13 +26,14 @@
           slim
         >
           <SfInput
+            v-on:click="getBackToShippingDetails()"
+            v-bind:class="{'disbale-input': isFormSubmitted}"
             v-model="form.email"
             label="Email"
             name="email"
             class="form__element"
             :valid="!errors[0]"
             :errorMessage="errors[0]"
-            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <ValidationProvider
@@ -38,6 +43,8 @@
           slim
         >
           <SfInput
+            v-on:click="getBackToShippingDetails()"
+            v-bind:class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-firstName'"
             v-model="form.firstName"
             label="First name"
@@ -46,7 +53,6 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
-            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <ValidationProvider
@@ -56,6 +62,8 @@
           slim
         >
           <SfInput
+            v-on:click="getBackToShippingDetails()"
+            v-bind:class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-lastName'"
             v-model="form.lastName"
             label="Last name"
@@ -64,7 +72,6 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
-            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <ValidationProvider
@@ -74,6 +81,8 @@
           slim
         >
           <SfInput
+            v-on:click="getBackToShippingDetails()"
+            v-bind:class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-streetName'"
             v-model="form.addressLine1"
             label="Street name"
@@ -82,16 +91,16 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
-            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <SfInput
+          v-on:click="getBackToShippingDetails()"
+          v-bind:class="{'disable-input': isFormSubmitted}"
           v-e2e="'shipping-apartment'"
           v-model="form.addressLine2"
           label="House/Apartment number"
           name="apartment"
           class="form__element"
-          :disabled="isFormSubmitted"
         />
         <ValidationProvider
           name="city"
@@ -100,6 +109,8 @@
           slim
         >
           <SfInput
+            v-on:click="getBackToShippingDetails()"
+            v-bind:class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-city'"
             v-model="form.city"
             label="City"
@@ -108,7 +119,6 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
-            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <ValidationProvider
@@ -119,6 +129,7 @@
           slim
         >
           <SfSelect
+            v-bind:class="{'disable-dropdown': isFormSubmitted}"
             data-cy="shipping-details-input_state"
             class="form__element form form__select sf-select--underlined"
             v-model="form.state"
@@ -127,7 +138,7 @@
             :required="isStateRequired"
             :valid="!errors[0]"
             :errorMessage="errors[0]"
-            :disabled="isFormSubmitted"
+            @input="getBackToShippingDetails()"
           >
             <SfSelectOption
               v-for="{ code, name } in states"
@@ -145,6 +156,7 @@
           slim
         >
           <SfSelect
+            v-bind:class="{'disable-dropdown': isFormSubmitted}"
             v-e2e="'shipping-country'"
             v-model="form.country"
             label="Country"
@@ -153,7 +165,7 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
-            :disabled="isFormSubmitted"
+            @input="getBackToShippingDetails()"
           >
             <SfSelectOption
               v-for="countryOption in countries"
@@ -171,6 +183,8 @@
           slim
         >
           <SfInput
+            v-on:click="getBackToShippingDetails()"
+            v-bind:class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-zipcode'"
             v-model="form.postalCode"
             label="Zip-code"
@@ -179,7 +193,6 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
-            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <ValidationProvider
@@ -189,6 +202,8 @@
           slim
         >
           <SfInput
+            v-on:click="getBackToShippingDetails()"
+            v-bind:class="{'disable-input': isFormSubmitted}"
             v-e2e="'shipping-phone'"
             v-model="form.phone"
             label="Phone number"
@@ -197,7 +212,6 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
-            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <SfCheckbox
@@ -316,6 +330,13 @@ export default {
 
       return savedAddresses.value.addresses.find(e => e._id === selectedSavedAddressId.value);
     });
+
+    const getBackToShippingDetails = () => {
+      if (isFormSubmitted.value) {
+        isFormSubmitted.value = !isFormSubmitted;
+      }
+    };
+
     const isStateRequired = computed(() => form.value.country && countries.value.find(e => e.key === form.value.country).stateRequired);
 
     const handleFormSubmit = async () => {
@@ -405,6 +426,7 @@ export default {
       checkoutShippingAddress,
       handleFormSubmit,
       isCopyToBillingSelected,
+      getBackToShippingDetails
     };
   }
 };
@@ -497,4 +519,17 @@ export default {
 .title {
   margin: var(--spacer-xl) 0 var(--spacer-base) 0;
 }
+.disable-input{
+    --input-border-color: var(--c-text-disabled);
+    --input-color: var(--c-text-disabled);
+    -webkit-text-fill-color: var(--c-text-disabled);
+
+}
+.disable-dropdown{
+  color: var(--c-text-disabled);
+  --select-dropdown-border-color: var(--c-text-disabled);
+  --select-label-color: var(--c-text-disabled);
+  --select-dropdown-color: var(--c-text-disabled);
+}
+
 </style>

--- a/packages/theme/pages/Checkout/Shipping.vue
+++ b/packages/theme/pages/Checkout/Shipping.vue
@@ -7,7 +7,7 @@
       class="sf-heading--left sf-heading--no-underline title"
     />
     <AddressPicker
-      v-if="isAuthenticated && savedAddresses"
+      v-if="isAuthenticated && savedAddresses && !isFormSubmitted"
       v-model="selectedSavedAddressId"
       :addresses="savedAddresses.addresses"
       :saved-address="checkoutShippingAddress"
@@ -28,6 +28,7 @@
             class="form__element"
             :valid="!errors[0]"
             :errorMessage="errors[0]"
+            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <ValidationProvider
@@ -45,6 +46,7 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
+            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <ValidationProvider
@@ -62,6 +64,7 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
+            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <ValidationProvider
@@ -79,6 +82,7 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
+            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <SfInput
@@ -87,6 +91,7 @@
           label="House/Apartment number"
           name="apartment"
           class="form__element"
+          :disabled="isFormSubmitted"
         />
         <ValidationProvider
           name="city"
@@ -103,6 +108,7 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
+            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <ValidationProvider
@@ -121,6 +127,7 @@
             :required="isStateRequired"
             :valid="!errors[0]"
             :errorMessage="errors[0]"
+            :disabled="isFormSubmitted"
           >
             <SfSelectOption
               v-for="{ code, name } in states"
@@ -146,6 +153,7 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
+            :disabled="isFormSubmitted"
           >
             <SfSelectOption
               v-for="countryOption in countries"
@@ -171,6 +179,7 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
+            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <ValidationProvider
@@ -188,6 +197,7 @@
             required
             :valid="!errors[0]"
             :errorMessage="errors[0]"
+            :disabled="isFormSubmitted"
           />
         </ValidationProvider>
         <SfCheckbox
@@ -409,7 +419,6 @@ export default {
     ::v-deep .sf-select__dropdown {
       font-size: var(--font-size--lg);
       margin: 0;
-      color: var(--c-text);
       font-family: var(--font-family--secondary);
       font-weight: var(--font-weight--normal);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Disabled an option to change shipping details when user already called for shipping methods

## Description
<!--- Describe your changes in detail -->

Removed possibility to change shipping details after user calls for shipping methods so it won't throw an error in special cases. Added a button that takes user back so she/he can provide details once more and choose appropriate shipping method. Also now while choosing shipping method user can go back to shipping details just by clicking on any of the input  fields or just by clicking saved address(only for logged in users)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#165
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It fixes #165
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/63898848/159522498-acb9943b-df44-4fc0-b731-039d23cb28a8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
