### PR TITLE
fix: orders history fixed

### DIFF
--- a/packages/api-client/src/api/serializers/cart.ts
+++ b/packages/api-client/src/api/serializers/cart.ts
@@ -60,8 +60,9 @@ const deserializeLineItem = (lineItem: any, attachments: JsonApiDocument[], conf
   };
 };
 
-const filterIncludedLineItems = (included: any[]) => {
-  return included.filter(e => e.type === 'line_item');
+const filterIncludedLineItems = (included: any[], apiCart) => {
+  const cartItemIds = apiCart.relationships.line_items.data.map(l => l.id);
+  return included.filter(e => e.type === 'line_item' && cartItemIds.includes(e.id));
 };
 
 const findAddress = (data, included) => {
@@ -90,7 +91,7 @@ export const deserializeCart = (apiCart: OrderAttr, included: any[], config: any
   shipTotalAmount: parseFloat(apiCart.attributes.ship_total),
   taxTotalAmount: parseFloat(apiCart.attributes.tax_total),
   adjustmentTotal: apiCart.attributes.display_adjustment_total,
-  lineItems: filterIncludedLineItems(included).map(item => deserializeLineItem(item, included, config)),
+  lineItems: filterIncludedLineItems(included, apiCart).map(item => deserializeLineItem(item, included, config)),
   itemCount: apiCart.attributes.item_count,
   address: findAddress(apiCart, included),
   completedAt: apiCart.attributes.completed_at,


### PR DESCRIPTION
## Description
Every order in the orders history was showing the same products. That was a problem related to deserialisation.

## Related Issue
Closes #183 

## How Has This Been Tested?
It was tested in the local environment connected to our test backend.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
