### PR TITLE
fix(#185): checkout and order products now link to themselves

### DIFF
--- a/packages/api-client/src/api/serializers/cart.ts
+++ b/packages/api-client/src/api/serializers/cart.ts
@@ -47,7 +47,7 @@ const deserializeLineItem = (lineItem: any, attachments: JsonApiDocument[], conf
     _description: '',
     _categoriesRef: [],
     name: lineItem.attributes.name,
-    sku: '',
+    sku: lineItem.attributes.slug,
     image: imageUrl,
     price: {
       original: lineItem.attributes.price,

--- a/packages/api-client/src/api/serializers/cart.ts
+++ b/packages/api-client/src/api/serializers/cart.ts
@@ -47,7 +47,8 @@ const deserializeLineItem = (lineItem: any, attachments: JsonApiDocument[], conf
     _description: '',
     _categoriesRef: [],
     name: lineItem.attributes.name,
-    sku: lineItem.attributes.slug,
+    sku: '',
+    slug: lineItem.attributes.slug,
     image: imageUrl,
     price: {
       original: lineItem.attributes.price,

--- a/packages/api-client/src/types/cart.ts
+++ b/packages/api-client/src/types/cart.ts
@@ -7,6 +7,7 @@ export type LineItem = {
   _categoriesRef: string[];
   name: string;
   sku: string;
+  slug: string;
   image: string;
   price: {
     original: number;

--- a/packages/composables/src/getters/cartGetters.ts
+++ b/packages/composables/src/getters/cartGetters.ts
@@ -3,7 +3,7 @@ import { Cart, LineItem } from '@vue-storefront/spree-api/src/types';
 
 export const getCartItems = (cart: Cart): LineItem[] => cart?.lineItems || [];
 
-export const getCartItemId = (lineItem: LineItem): number => lineItem?._variantId;
+export const getCartItemVariantId = (lineItem: LineItem): number => lineItem?._variantId;
 
 export const getCartItemName = (lineItem: LineItem): string => lineItem.name;
 
@@ -55,7 +55,7 @@ const cartGetters: CartGetters<Cart, LineItem> = {
   getTotals: getCartTotals,
   getShippingPrice: getCartShippingPrice,
   getItems: getCartItems,
-  getItemId: getCartItemId,
+  getItemVariantId: getCartItemVariantId,
   getItemName: getCartItemName,
   getItemImage: getCartItemImage,
   getItemPrice: getCartItemPrice,

--- a/packages/composables/src/getters/cartGetters.ts
+++ b/packages/composables/src/getters/cartGetters.ts
@@ -29,6 +29,8 @@ export const getCartItemAttributes = (lineItem: LineItem, filters?: Array<string
 
 export const getCartItemSku = (lineItem: LineItem): string => lineItem.sku;
 
+export const getCartItemSlug = (lineItem: LineItem): string => lineItem.slug;
+
 export const getCartTotals = (cart: Cart): AgnosticTotals => {
   return {
     total: cart?.totalAmount || 0,
@@ -61,6 +63,7 @@ const cartGetters: CartGetters<Cart, LineItem> = {
   getItemQty: getCartItemQty,
   getItemAttributes: getCartItemAttributes,
   getItemSku: getCartItemSku,
+  getItemSlug: getCartItemSlug,
   getFormattedPrice: getFormattedPrice,
   getTotalItems: getCartTotalItems,
   getCoupons,

--- a/packages/composables/src/getters/cartGetters.ts
+++ b/packages/composables/src/getters/cartGetters.ts
@@ -3,6 +3,8 @@ import { Cart, LineItem } from '@vue-storefront/spree-api/src/types';
 
 export const getCartItems = (cart: Cart): LineItem[] => cart?.lineItems || [];
 
+export const getCartItemId = (lineItem: LineItem): number => lineItem?._variantId;
+
 export const getCartItemName = (lineItem: LineItem): string => lineItem.name;
 
 export const getCartItemImage = (lineItem: LineItem): string => lineItem.image;
@@ -51,6 +53,7 @@ const cartGetters: CartGetters<Cart, LineItem> = {
   getTotals: getCartTotals,
   getShippingPrice: getCartShippingPrice,
   getItems: getCartItems,
+  getItemId: getCartItemId,
   getItemName: getCartItemName,
   getItemImage: getCartItemImage,
   getItemPrice: getCartItemPrice,

--- a/packages/composables/src/getters/orderGetters.ts
+++ b/packages/composables/src/getters/orderGetters.ts
@@ -13,6 +13,8 @@ export const getPrice = (order: Order): number | null => order?.totalAmount || 0
 
 export const getItems = (order: Order): any[] => order?.lineItems || [];
 
+export const getItemId = (item: OrderItem): string => item?._variantId || 0;
+
 export const getItemSku = (item: OrderItem): string => item?.sku || '';
 
 export const getItemName = (item: OrderItem): string => item?.name || '';
@@ -31,6 +33,7 @@ const orderGetters: UserOrderGetters<Order, OrderItem> = {
   getStatus,
   getPrice,
   getItems,
+  getItemId,
   getItemSku,
   getItemName,
   getItemQty,

--- a/packages/composables/src/getters/orderGetters.ts
+++ b/packages/composables/src/getters/orderGetters.ts
@@ -13,7 +13,7 @@ export const getPrice = (order: Order): number | null => order?.totalAmount || 0
 
 export const getItems = (order: Order): any[] => order?.lineItems || [];
 
-export const getItemId = (item: OrderItem): string => item?._variantId || 0;
+export const getItemVariantId = (item: OrderItem): string => item?._variantId || 0;
 
 export const getItemSku = (item: OrderItem): string => item?.sku || '';
 
@@ -35,7 +35,7 @@ const orderGetters: UserOrderGetters<Order, OrderItem> = {
   getStatus,
   getPrice,
   getItems,
-  getItemId,
+  getItemVariantId,
   getItemSku,
   getItemSlug,
   getItemName,

--- a/packages/composables/src/getters/orderGetters.ts
+++ b/packages/composables/src/getters/orderGetters.ts
@@ -17,6 +17,8 @@ export const getItemId = (item: OrderItem): string => item?._variantId || 0;
 
 export const getItemSku = (item: OrderItem): string => item?.sku || '';
 
+export const getItemSlug = (item: OrderItem): string => item?.slug || '';
+
 export const getItemName = (item: OrderItem): string => item?.name || '';
 
 export const getItemQty = (item: OrderItem): number => item?.qty || 0;
@@ -35,6 +37,7 @@ const orderGetters: UserOrderGetters<Order, OrderItem> = {
   getItems,
   getItemId,
   getItemSku,
+  getItemSlug,
   getItemName,
   getItemQty,
   getItemPrice,

--- a/packages/theme/components/CartSidebar.vue
+++ b/packages/theme/components/CartSidebar.vue
@@ -28,6 +28,7 @@
                 :regular-price="$n(cartGetters.getItemPrice(product).regular, 'currency')"
                 :special-price="cartGetters.getItemPrice(product).special && $n(cartGetters.getItemPrice(product).special, 'currency')"
                 :stock="99999"
+                :link="localePath(`/p/${cartGetters.getItemId(product)}/${cartGetters.getItemSku(product)}`)"
                 @click:remove="removeItem({ product: { id: product.id } })"
                 class="collected-product"
               >

--- a/packages/theme/components/CartSidebar.vue
+++ b/packages/theme/components/CartSidebar.vue
@@ -28,7 +28,7 @@
                 :regular-price="$n(cartGetters.getItemPrice(product).regular, 'currency')"
                 :special-price="cartGetters.getItemPrice(product).special && $n(cartGetters.getItemPrice(product).special, 'currency')"
                 :stock="99999"
-                :link="localePath(`/p/${cartGetters.getItemId(product)}/${cartGetters.getItemSku(product)}`)"
+                :link="localePath(`/p/${cartGetters.getItemId(product)}/${cartGetters.getItemSlug(product)}`)"
                 @click:remove="removeItem({ product: { id: product.id } })"
                 class="collected-product"
               >

--- a/packages/theme/pages/MyAccount/OrderHistory.vue
+++ b/packages/theme/pages/MyAccount/OrderHistory.vue
@@ -33,7 +33,7 @@
           </SfTableHeading>
           <SfTableRow v-for="(item, i) in orderGetters.getItems(currentOrder)" :key="i">
             <SfTableData class="products__name">
-              <nuxt-link :to="localePath(`/p/${orderGetters.getItemId(item)}/${orderGetters.getItemSku(item)}`)">
+              <nuxt-link :to="localePath(`/p/${orderGetters.getItemId(item)}/${orderGetters.getItemSlug(item)}`)">
                 {{orderGetters.getItemName(item)}}
               </nuxt-link>
             </SfTableData>

--- a/packages/theme/pages/MyAccount/OrderHistory.vue
+++ b/packages/theme/pages/MyAccount/OrderHistory.vue
@@ -33,7 +33,7 @@
           </SfTableHeading>
           <SfTableRow v-for="(item, i) in orderGetters.getItems(currentOrder)" :key="i">
             <SfTableData class="products__name">
-              <nuxt-link :to="localePath(`/p/${orderGetters.getItemId(item)}/${orderGetters.getItemSlug(item)}`)">
+              <nuxt-link :to="localePath(`/p/${orderGetters.getItemVariantId(item)}/${orderGetters.getItemSlug(item)}`)">
                 {{orderGetters.getItemName(item)}}
               </nuxt-link>
             </SfTableData>

--- a/packages/theme/pages/MyAccount/OrderHistory.vue
+++ b/packages/theme/pages/MyAccount/OrderHistory.vue
@@ -33,7 +33,7 @@
           </SfTableHeading>
           <SfTableRow v-for="(item, i) in orderGetters.getItems(currentOrder)" :key="i">
             <SfTableData class="products__name">
-              <nuxt-link :to="'/p/'+orderGetters.getItemSku(item)+'/'+orderGetters.getItemSku(item)">
+              <nuxt-link :to="localePath(`/p/${orderGetters.getItemId(item)}/${orderGetters.getItemSku(item)}`)">
                 {{orderGetters.getItemName(item)}}
               </nuxt-link>
             </SfTableData>


### PR DESCRIPTION
## Description
Products in the Order History didn't redirect to their pages, instead they did redirect to blank "not found" pages. These changes introduce proper id and slug passing, so there can be proper links created. Also did the same thing for products in the cart. 

## Related Issue
Closes #185 
## Motivation and Context
Changes for the cart and order history give more natural and intuitive feeling while using the app.

## How Has This Been Tested?
It was tested in the local environment connected to our Heroku backend.

## Screenshots (if appropriate):
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/49924891/160415388-77a0bf9b-c1f5-43dd-aebd-e7646a2ef843.png">
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/49924891/160415662-282b7160-1b96-42a1-8ada-d03afd4e40d6.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
