### PR TITLE
fix: update deserializing line item image

### DIFF
--- a/packages/api-client/src/api/serializers/cart.ts
+++ b/packages/api-client/src/api/serializers/cart.ts
@@ -39,7 +39,7 @@ const deserializeLineItem = (lineItem: any, attachments: JsonApiDocument[], conf
   const imagesData = variantImagesData.length > 0 ? variantImagesData : productImagesData;
   const image = findAttachment(attachments, imagesData[0]?.id, 'image');
 
-  const imageUrl = image ? formatImageUrl(image.attributes.styles, config.backendUrl) : '';
+  const imageUrl = image ? formatImageUrl(image.attributes.styles, config) : '';
 
   return {
     id: parseInt(lineItem.id, 10),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`formatImageUrl` function needs `config` object as a param (in order to have an access to `backendUrl` and `assetsUrl`), but in the `deserializeLineItem` function, we are passing `backendUrl` string instead. That's why when line item has an image, `formatImageUrl` function throws an error (can't read `.concat` of `undefined`)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
