### PR TITLE
feat(#179): add preselection to shipping methods

### DIFF
--- a/packages/theme/components/Checkout/ShippingRatePicker.vue
+++ b/packages/theme/components/Checkout/ShippingRatePicker.vue
@@ -56,6 +56,11 @@ export default {
     };
   },
 
+  mounted() {
+    const preselectedRateId = (this.shippingRates?.find((rate) => rate?.selected)?.id) ?? null;
+    this.selectRate(preselectedRateId);
+  },
+
   computed: {
     shippingRates() {
       return this.shipment.availableShippingRates;

--- a/packages/theme/components/Checkout/VsfShippingProvider.vue
+++ b/packages/theme/components/Checkout/VsfShippingProvider.vue
@@ -49,7 +49,6 @@ export default {
 
     onMounted(async () => {
       await loadShipments();
-      selectedShippingRates.value = shipments.value.reduce((prev, curr) => ({...prev, [curr.id]: null }), {});
     });
 
     const selectShippingRate = (shipmentId, shippingRateId) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With this commit, all shippings are preselected with data returned from the API.

## Description
<!--- Describe your changes in detail -->

I've removed code responsible for constructing `selectedShippingRates` object and created a `mounted` lifecycle option in the `ShippingRatePicker` which indirectly calls `selectShippingRate` with shipmentId and shippingRateId instead. Added defensive check to make sure all required shippings are added to the `selectedShippingRates` by the `ShippingRatePicker`-s calls.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#179 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Poor UX. Users had the shipping method selected, but returning to the shipping view and opening the shipping method step again wouldn't show that to them in the UI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):


https://user-images.githubusercontent.com/18665370/160780710-783f32f2-7259-4934-a7c3-8337fa002e40.mov



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
