### PR TITLE
fix(theme): remove unused routes from the nuxt router

### DIFF
--- a/packages/theme/__tests__/helpers/excludeRoutes.spec.ts
+++ b/packages/theme/__tests__/helpers/excludeRoutes.spec.ts
@@ -1,0 +1,194 @@
+import { excludeRoutes } from '../../helpers/excludeRoutes';
+import { routes as mockedRoutes } from '../test-data/excludeRoutes';
+
+describe('[theme-helpers] excludeRoutes', () => {
+  it('excludes paths at root level from large object', () => {
+    const testData = mockedRoutes;
+    const pathsToExclude = ['Test'];
+    const expected = [];
+    expect(excludeRoutes(testData, pathsToExclude)).toEqual(expected);
+  });
+  it('excludes nested routes', () => {
+    const testData = [
+      {
+        name: 'Test',
+        path: '/Test',
+        component: '...',
+        chunkName: '...',
+        children: [
+          {
+            name: 'A',
+            path: 'A',
+            component: '...',
+            chunkName: '...'
+          },
+          {
+            name: 'C',
+            path: 'C',
+            component: '...',
+            chunkName: '...'
+          },
+          {
+            name: 'D',
+            path: 'D',
+            component: '...',
+            chunkName: '...'
+          }
+        ]
+      }
+    ];
+    const pathsToExclude = ['Test/C', 'Test/D'];
+    const expected = [
+      {
+        name: 'Test',
+        path: '/Test',
+        component: '...',
+        chunkName: '...',
+        children: [
+          {
+            name: 'A',
+            path: 'A',
+            component: '...',
+            chunkName: '...'
+          }
+        ]
+      }
+    ];
+    expect(excludeRoutes(testData, pathsToExclude)).toEqual(expected);
+  });
+  it('excludes all nested routes and removes children attribute', () => {
+    const testData = [
+      {
+        name: 'Test',
+        path: '/Test',
+        component: '...',
+        chunkName: '...',
+        children: [
+          {
+            name: 'A',
+            path: 'A',
+            component: '...',
+            chunkName: '...'
+          },
+          {
+            name: 'B',
+            path: 'B',
+            component: '...',
+            chunkName: '...'
+          },
+          {
+            name: 'C',
+            path: 'C',
+            component: '...',
+            chunkName: '...'
+          },
+          {
+            name: 'D',
+            path: 'D',
+            component: '...',
+            chunkName: '...'
+          }
+        ]
+      }
+    ];
+    const pathsToExclude = ['Test/A', 'Test/B', 'Test/C', 'Test/D'];
+    const expected = [
+      {
+        name: 'Test',
+        path: '/Test',
+        component: '...',
+        chunkName: '...'
+      }
+    ];
+    expect(excludeRoutes(testData, pathsToExclude)).toEqual(expected);
+  });
+  it('excludes multiply-nested routes', () => {
+    const testData = [
+      {
+        name: 'Test',
+        path: '/Test',
+        component: '...',
+        chunkName: '...',
+        children: [
+          {
+            name: 'A',
+            path: 'A',
+            component: '...',
+            chunkName: '...',
+            children: [
+              {
+                name: 'AA',
+                path: 'AA',
+                component: '...',
+                chunkName: '...'
+              },
+              {
+                name: 'AB',
+                path: 'AB',
+                component: '...',
+                chunkName: '...'
+              }
+            ]
+          },
+          {
+            name: 'C',
+            path: 'C',
+            component: '...',
+            chunkName: '...'
+          }
+        ]
+      }
+    ];
+    const pathsToExclude = ['Test/A/AA', 'Test/A/AB'];
+    const expected = [
+      {
+        name: 'Test',
+        path: '/Test',
+        component: '...',
+        chunkName: '...',
+        children: [
+          {
+            name: 'A',
+            path: 'A',
+            component: '...',
+            chunkName: '...'
+          },
+          {
+            name: 'C',
+            path: 'C',
+            component: '...',
+            chunkName: '...'
+          }
+        ]
+      }
+    ];
+    expect(excludeRoutes(testData, pathsToExclude)).toEqual(expected);
+  });
+  it('returns the same routes object if root path does not exist', () => {
+    const testData = mockedRoutes;
+    const pathsToExclude = ['ThisPathDoesNotExist'];
+    const expected = mockedRoutes;
+    expect(excludeRoutes(testData, pathsToExclude)).toEqual(expected);
+  });
+  it('returns the same routes object if neither of paths exist', () => {
+    const testData = mockedRoutes;
+    const pathsToExclude = [
+      'ThisPathDoesNotExist',
+      'ThisPathDoesNotExist/ThisPathDoesNotExist2/ThisPathDoesNotExist3'
+    ];
+    const expected = mockedRoutes;
+    expect(excludeRoutes(testData, pathsToExclude)).toEqual(expected);
+  });
+  it('returns the same routes object if all paths exist but the leaf with one nesting', () => {
+    const testData = mockedRoutes;
+    const pathsToExclude = ['Test/FormerPathsExistButThisOneNot'];
+    const expected = mockedRoutes;
+    expect(excludeRoutes(testData, pathsToExclude)).toEqual(expected);
+  });
+  it('returns the same routes object if all paths exist but the leaf with multiple nestings', () => {
+    const testData = mockedRoutes;
+    const pathsToExclude = ['Test/A/AA/FormerPathsExistButThisOneNot'];
+    const expected = mockedRoutes;
+    expect(excludeRoutes(testData, pathsToExclude)).toEqual(expected);
+  });
+});

--- a/packages/theme/__tests__/test-data/excludeRoutes.ts
+++ b/packages/theme/__tests__/test-data/excludeRoutes.ts
@@ -1,0 +1,50 @@
+import { NuxtRouteConfig } from '@nuxt/types/config/router';
+
+export const routes: NuxtRouteConfig[] = [
+  {
+    name: 'Test',
+    path: '/Test',
+    component: '...',
+    chunkName: '...',
+    children: [
+      {
+        name: 'A',
+        path: 'A',
+        component: '...',
+        chunkName: '...',
+        children: [
+          {
+            name: 'AA',
+            path: 'AA',
+            component: '...',
+            chunkName: '...'
+          },
+          {
+            name: 'AB',
+            path: 'AB',
+            component: '...',
+            chunkName: '...'
+          }
+        ]
+      },
+      {
+        name: 'C',
+        path: 'C',
+        component: '...',
+        chunkName: '...'
+      },
+      {
+        name: 'D',
+        path: 'D',
+        component: '...',
+        chunkName: '...'
+      },
+      {
+        name: 'E',
+        path: 'E',
+        component: '...',
+        chunkName: '...'
+      }
+    ]
+  }
+];

--- a/packages/theme/helpers/excludeRoutes.ts
+++ b/packages/theme/helpers/excludeRoutes.ts
@@ -1,0 +1,150 @@
+import { NuxtRouteConfig } from '@nuxt/types/config/router';
+
+/**
+ * @param excludeSelf - If true, a given node (and all its descendants) are removed from the tree.
+ * @example
+ * // Nodes A, B, C, D, Z will be removed from the tree
+ * // A: {
+ * //   excludeSelf: true,
+ * //   children: {
+ * //     B: { excludeSelf: ..., children: ... },
+ * //     C: { excludeSelf: ..., children: ... },
+ * //     D: { excludeSelf: ..., children: ... }
+ * //   }
+ * // },
+ * // X: {
+ * //   excludeSelf: false,
+ * //   children: {
+ * //     Y: {
+ * //       excludeSelf: false,
+ * //       children: {
+ * //         Z: {
+ * //           excludeSelf: true,
+ * //           children: null
+ * //         }
+ * //       }
+ * //     }
+ * //   }
+ * // }
+ * @param children - A node descendants with unique paths as object keys.
+ * @example
+ * // A: {
+ * //   excludeSelf: false,
+ * //   children: {
+ * //     B: {
+ * //      excludeSelf: false,
+ * //      children: {
+ * //        C: {
+ * //          excludeSelf: true,
+ * //          children: null
+ * //        }
+ * //     },
+ * //     D: { excludeSelf: true, children: null },
+ * //     F: { excludeSelf: true, children: null }
+ * //   }
+ * // }
+ */
+interface TreeNode {
+  excludeSelf: boolean;
+  children: { [path: string]: TreeNode } | null;
+}
+
+type Paths = string[];
+
+/**
+ * Builds a tree of paths based on pathsToExlude
+ * @example
+ * // pathsToExclude = [ 'a/b/c', 'a/b/d/e', 'x' ]
+ * // buildPathsTree returns:
+ * // '/a': {
+ * //   excludeSelf: false,
+ * //   children: {
+ * //     b: {
+ * //       excludeSelf: false,
+ * //       children: {
+ * //         c: {
+ * //           excludeSelf: true,
+ * //           children: null
+ * //         },
+ * //         d: {
+ * //           excludeSelf: false,
+ * //           children: {
+ * //             e: {
+ * //               excludeSelf: true,
+ * //               children: null
+ * //             }
+ * //           }
+ * //         }
+ * //       }
+ * //     }
+ * //   }
+ * // },
+ * // '/x': {
+ * //   excludeSelf: true,
+ * //   children: null
+ * // }
+ */
+const buildPathsTree = (pathsToExclude: Paths) => {
+  const buildBranch = (
+    root: { [key: string]: TreeNode },
+    pathArray,
+    depth = 0
+  ) => {
+    const isLeaf = depth === pathArray.length - 1;
+    const path = pathArray[depth];
+    // Nuxt router sets root path with '/' as a prefix.
+    const key = depth === 0 ? `/${path}` : path;
+    if (!root[key]) {
+      root[key] = {
+        excludeSelf: isLeaf,
+        children: isLeaf ? null : {}
+      } as TreeNode;
+    }
+    if (root[key].excludeSelf) return;
+    buildBranch(root[key].children, pathArray, depth + 1);
+  };
+  return pathsToExclude
+    .map((path) => path.split('/'))
+    .reduce((tree, paths) => {
+      buildBranch(tree, paths);
+      return tree;
+    }, {});
+};
+
+/**
+ * Excludes paths recursively. Advances node level if given route in routes has any children.
+ * Checks if given route in routes should be deleted before advancing the node level
+ * (so that it won't call a deeper recursion).
+ */
+const excludeRecursively = (routes: NuxtRouteConfig[], node) => {
+  return routes?.reduce((arr, route) => {
+    const routeNode = node[route.path];
+    if (!routeNode) return [...arr, route];
+    if (routeNode.excludeSelf) return arr;
+    const children = excludeRecursively(route.children, routeNode.children);
+    if (!children) return [...arr, route];
+    const updatedRoute = {...route, children };
+    if (!children.length) delete updatedRoute.children;
+    return [...arr, updatedRoute];
+  }, []);
+};
+
+/**
+ * Excludes paths from given Nuxt routes array based on absolute paths specified in the pathsToExclude.
+ *
+ * Uses recursion to delete nested paths from the routes array.
+ * Traverses over a created tree of paths based on the given pathsToExclude array,
+ * to verify which paths on a given tree level are to be deleted.
+ *
+ * @param routes - A routes returned by the extendRoutes Nuxt function
+ * @param pathsToExclude - Absolute paths that will be removed from the routes array.
+ *
+ * @returns routes array with excluded paths specified in the pathsToExclude array.
+ */
+export const excludeRoutes = (
+  routes: NuxtRouteConfig[],
+  pathsToExclude: Paths
+): NuxtRouteConfig[] => {
+  const excludeTree = buildPathsTree(pathsToExclude);
+  return excludeRecursively(routes, excludeTree);
+};

--- a/packages/theme/jest.config.ts
+++ b/packages/theme/jest.config.ts
@@ -1,0 +1,10 @@
+import type {Config} from '@jest/types';
+
+const config: Config.InitialOptions = {
+  verbose: true,
+  transform: {
+    '^.+\\.(ts)$': 'ts-jest'
+  },
+  testMatch: ['<rootDir>/**/__tests__/**/*spec.[jt]s?(x)']
+};
+export default config;

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -1,5 +1,6 @@
 import webpack from 'webpack';
 import theme from './themeConfig';
+import { excludeRoutes } from './helpers/excludeRoutes';
 
 export default {
   ssr: true,
@@ -178,6 +179,13 @@ export default {
       } else {
         return { x: 0, y: 0 };
       }
+    },
+    extendRoutes(routes) {
+      routes = excludeRoutes(routes, [
+        'MyAccount/MyNewsletter',
+        'MyAccount/ShippingDetails',
+        'MyAccount/BillingDetails'
+      ]);
     }
   },
   publicRuntimeConfig: {

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -132,9 +132,8 @@ export default {
             currencyDefault: 'EUR'
           }
         }
-      },
-    },
-    detectBrowserLanguage: false
+      }
+    }
   },
   pwa: {
     meta: {

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -26,7 +26,8 @@
     "types": [
       "@types/node",
       "@nuxt/types",
-      "nuxt-i18n"
+      "nuxt-i18n",
+      "@types/jest"
     ],
     "resolveJsonModule": true,
     "rootDir": "./",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I've created a tree-traversal function to exclude specified paths from given routes, and used it inside of the Nuxt config file, to remove unused routes, that we've recently deleted from the UI (shipping, billing, my newsletter).

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We've removed some of the pages served by the vue-storefront (MyNewsletter, BillingDetails, ShippingDetails, ...). Those pages were still visible in the router.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
