### PR TITLE
fix: rendering products' descriptions fixed

### DIFF
--- a/packages/theme/pages/Product.vue
+++ b/packages/theme/pages/Product.vue
@@ -85,7 +85,7 @@
         <LazyHydrate when-idle>
           <SfTabs :open-tab="1" class="product__tabs">
             <SfTab title="Description" style="padding: 0; margin: 0">
-              <p class="product__description" style="padding: 0; margin: 0">{{ productGetters.getDescription(product) }}</p>
+              <div v-html="productGetters.getDescription(product)" class="product__description" style="padding: 0; margin: 0"></div>
             </SfTab>
             <SfTab title="Read reviews">
               <SfReview

--- a/packages/theme/pages/Product.vue
+++ b/packages/theme/pages/Product.vue
@@ -85,7 +85,7 @@
         <LazyHydrate when-idle>
           <SfTabs :open-tab="1" class="product__tabs">
             <SfTab title="Description" style="padding: 0; margin: 0">
-              <div v-html="productGetters.getDescription(product)" class="product__description" style="padding: 0; margin: 0"></div>
+              <div v-html="productGetters.getDescription(product)" class="product__description" ></div>
             </SfTab>
             <SfTab title="Read reviews">
               <SfReview
@@ -338,6 +338,8 @@ export default {
       1.6,
       var(--font-family--secondary)
     );
+    padding: 0;
+    margin: 0;
   }
   &__select-size {
     margin: 0 var(--spacer-sm);


### PR DESCRIPTION
## Description
There was an issue where backend returned products' descriptions including the html tags, which were shown instead of compiled. These changes fix it.

## How Has This Been Tested?
Local environment with our backend.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
