### PR TITLE
feat(#201): products in the cart now display option values only if they exist

### DIFF
--- a/packages/theme/components/CartSidebar.vue
+++ b/packages/theme/components/CartSidebar.vue
@@ -36,6 +36,7 @@
                   <div class="collected-product__properties">
                     <SfProperty
                       v-for="(attribute, key) in cartGetters.getItemAttributes(product, ['color', 'size'])"
+                      v-if="attribute"
                       :key="key"
                       :name="key"
                       :value="attribute"


### PR DESCRIPTION
## Description
Products' option values were displayed even if there was blank space, now they're shown only if they exist.

## Related Issue
Closes #201 

## How Has This Been Tested?
Local environment with Spree 4.4 backend on Heroku.

## Screenshots (if appropriate):
Before
<img width="384" alt="image" src="https://user-images.githubusercontent.com/49924891/162177321-66f46a38-a236-471a-b0a8-d48f431aee93.png">
After
<img width="384" alt="image" src="https://user-images.githubusercontent.com/49924891/162177552-34d0029c-cff0-426f-8024-44b6a2311ea0.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
