### PR TITLE
feat(theme): add support for visible alternative text in cover images

### DIFF
--- a/packages/theme/assets/components/_SfProductCard.scss
+++ b/packages/theme/assets/components/_SfProductCard.scss
@@ -1,0 +1,32 @@
+@mixin SfProductCard() {
+  .sf-product-card,
+  .sf-product-card-horizontal {
+    display: flex;
+    &__image-wrapper .sf-product-card__link {
+      height: 100%;
+    }
+    &__image {
+      width: 100%;
+      height: 100%;
+      .sf-image {
+        display: block;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        opacity: 1;
+        font-weight: normal;
+        line-height: 1.6;
+        color: var(--c-primary);
+      }
+    }
+  }
+  .sf-product-card {
+    flex-flow: column;
+    &__image-wrapper {
+      flex-basis: 100%;
+    }
+  }
+  .sf-product-card-horizontal {
+    flex-flow: row;
+  }
+}

--- a/packages/theme/assets/styles.scss
+++ b/packages/theme/assets/styles.scss
@@ -1,0 +1,3 @@
+#__nuxt {
+  @include SfProductCard;
+}

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -157,6 +157,9 @@ export default {
     },
     display: 'swap'
   },
+  css: [
+    '~/assets/styles.scss'
+  ],
   styleResources: {
     scss: [require.resolve('@storefront-ui/shared/styles/_helpers.scss', { paths: [process.cwd()] })]
   },

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -161,7 +161,10 @@ export default {
     '~/assets/styles.scss'
   ],
   styleResources: {
-    scss: [require.resolve('@storefront-ui/shared/styles/_helpers.scss', { paths: [process.cwd()] })]
+    scss: [
+      require.resolve('@storefront-ui/shared/styles/_helpers.scss', { paths: [process.cwd()] }),
+      '~/assets/components/*.scss'
+    ]
   },
   build: {
     transpile: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With this commit, alternative text on image cards is visible and overflows with an ellipsis. Additionally, image containers inside of image cards fill the empty space, to match other containers' heights in the row and no longer shrink if the image is not available.

I've also added support for the global SCSS styles and created an assets/components directory for partials overriding components' styles globally which are linked using `styleResources` in the nuxt.config file.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screenshot 2022-04-12 at 08 39 19](https://user-images.githubusercontent.com/18665370/162896776-35997674-285f-4b95-b7cd-4b8fa9b4f6
![Screenshot 2022-04-12 at 08 40 08](https://user-images.githubusercontent.com/18665370/162896849-38275b13-da5a-4557-96ec-6965b4729068.png)
14.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
