### PR TITLE
fix(theme): update mobile-observer usage with computed property accessed via its getter

### DIFF
--- a/packages/theme/components/AppHeader.vue
+++ b/packages/theme/components/AppHeader.vue
@@ -109,7 +109,7 @@
 import { SfHeader, SfImage, SfIcon, SfButton, SfBadge, SfSearchBar, SfOverlay } from '@storefront-ui/vue';
 import { useUiState } from '~/composables';
 import { useCart, useFacet, useUser, cartGetters, useWishlist, wishlistGetters } from '@vue-storefront/spree';
-import { computed, ref, watch, onBeforeUnmount, useRouter, onUpdated } from '@nuxtjs/composition-api';
+import { computed, ref, watch, onBeforeUnmount, useRouter } from '@nuxtjs/composition-api';
 import { useUiHelpers } from '~/composables';
 import LocaleSelector from './LocaleSelector';
 import SearchResults from '~/components/SearchResults';
@@ -146,7 +146,7 @@ export default {
     const term = ref(getFacetsFromURL().phrase);
     const isSearchOpen = ref(false);
     const searchBarRef = ref(null);
-    const isMobile = ref(mapMobileObserver().isMobile.get());
+    const isMobile = computed(mapMobileObserver().isMobile);
 
     const result = computed(() => searchResult.value?.data);
     const cartTotalItems = computed(() => cartGetters.getTotalItems(cart.value));
@@ -200,10 +200,6 @@ export default {
     });
 
     const removeSearchResults = () => {};
-
-    onUpdated(() => {
-      mapMobileObserver();
-    });
 
     onBeforeUnmount(() => {
       unMapMobileObserver();

--- a/packages/theme/pages/MyAccount.vue
+++ b/packages/theme/pages/MyAccount.vue
@@ -64,7 +64,7 @@ export default {
     const route = useRoute();
     const router = useRouter();
     const { logout } = useUser();
-    const isMobile = computed(() => mapMobileObserver().isMobile.get());
+    const isMobile = computed(mapMobileObserver().isMobile);
     const activePage = computed(() => {
       const { pageName } = route.value.params;
       if (!pageName) return isMobile.value ? '' : 'My profile';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With this commit, the isMobile property (with its own getter method) of the mobile-observer utility is exposed inside of the computed value, and not using ref() or computed(() => ...), which may lead to unwanted results.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
