### PR TITLE
fix: nullish coalescing type signature return value

### DIFF
--- a/packages/api-client/src/api/serializers/product.ts
+++ b/packages/api-client/src/api/serializers/product.ts
@@ -148,7 +148,7 @@ const partialDeserializeProductVariant = (
   inStock: variant.attributes.in_stock
 });
 
-const maybePrimaryVariantId = (product: ProductAttr): RelationType['id'] | null =>
+const maybePrimaryVariantId = (product: ProductAttr): RelationType['id'] | undefined =>
   // primary_variant may not exist if an older version of Spree is used. Only use primary_variant if available.
   (product.relationships.primary_variant?.data as RelationType)?.id;
 


### PR DESCRIPTION
The type signature was invalid - nullish coalescing returns `undefined`.