### PR TITLE
chore: use type-only exports to avoid import warnings

### DIFF
--- a/packages/composables/src/types/index.ts
+++ b/packages/composables/src/types/index.ts
@@ -29,7 +29,7 @@ export type UseCountry = {
   loadStates(key: string): Promise<void>;
 };
 
-export { Cart, Order, LineItem, ProductVariant, Category, Wishlist, User } from '@vue-storefront/spree-api';
+export type { Cart, Order, LineItem, ProductVariant, Category, Wishlist, User } from '@vue-storefront/spree-api';
 
 export type UserAddress = Record<string, unknown>;
 


### PR DESCRIPTION
## Issue
Errors while compiling:
```
[dev:theme]  WARN  Compiled with 7 warnings
[dev:theme]
[dev:theme]
[dev:theme]  WARN  in ../composables/lib/index.es.js
[dev:theme]
[dev:theme]
[dev:theme]  WARN  in ../composables/lib/index.es.js
[dev:theme]
[dev:theme] "export 'Cart' was not found in '@vue-storefront/spree-api'
[dev:theme]
[dev:theme] "export 'Category' was not found in '@vue-storefront/spree-api'
[dev:theme]
[dev:theme] "export 'LineItem' was not found in '@vue-storefront/spree-api'
[dev:theme]
[dev:theme]
[dev:theme]  WARN  in ../composables/lib/index.es.js
[dev:theme]
[dev:theme]
[dev:theme]  WARN  in ../composables/lib/index.es.js
[dev:theme]
[dev:theme]
[dev:theme]  WARN  in ../composables/lib/index.es.js
[dev:theme]
[dev:theme] "export 'Order' was not found in '@vue-storefront/spree-api'
[dev:theme]
[dev:theme] "export 'ProductVariant' was not found in '@vue-storefront/spree-api'
[dev:theme]
[dev:theme]
[dev:theme]  WARN  in ../composables/lib/index.es.js
[dev:theme]
[dev:theme] "export 'User' was not found in '@vue-storefront/spree-api'
[dev:theme]
[dev:theme]
[dev:theme]  WARN  in ../composables/lib/index.es.js
[dev:theme]
[dev:theme] "export 'Wishlist' was not found in '@vue-storefront/spree-api
```

## Cause
Types and interfaces do not exist after TypeScript transpilation hence the import is missing. 