### PR TITLE
chore: do not mark the `yarn build` step as optional in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ yarn install
 export BACKEND_URL=https://demo.spreecommerce.org
 ```
 
-4. (optional) Then you can verify if everything works properly by building all three projects:
+4. Then build all three projects:
 
 ```sh
 yarn build


### PR DESCRIPTION
I don't think it's optional. E.g. `api-client` has to be built before `composables` and `theme` and `yarn dev` does not guarantee that because it runs the tasks concurrently. This leads to errors such as these:

```
[dev:composables] [!] (plugin rpt2) Error: /Users/karolszuster/Upside/vsf/tmp/spree/packages/composables/src/useBilling/index.ts(2,25): semantic error TS2307: Cannot find module '@vue-storefront/spree-api' or its corresponding type declarations.
[dev:composables] src/useBilling/index.ts
[dev:composables] Error: /Users/karolszuster/Upside/vsf/tmp/spree/packages/composables/src/useBilling/index.ts(2,25): semantic error TS2307: Cannot find module '@vue-storefront/spree-api' or its corresponding type declarations.
[dev:composables]     at error (/Users/karolszuster/Upside/vsf/tmp/spree/node_modules/rollup/dist/shared/rollup.js:158:30)
[dev:composables]     at throwPluginError (/Users/karolszuster/Upside/vsf/tmp/spree/node_modules/rollup/dist/shared/rollup.js:21741:12)
[dev:composables]     at Object.error (/Users/karolszuster/Upside/vsf/tmp/spree/node_modules/rollup/dist/shared/rollup.js:22415:20)
[dev:composables]     at Object.error (/Users/karolszuster/Upside/vsf/tmp/spree/node_modules/rollup/dist/shared/rollup.js:21917:38)
[dev:composables]     at RollupContext.error (/Users/karolszuster/Upside/vsf/tmp/spree/node_modules/rollup-plugin-typescript2/src/rollupcontext.ts:37:18)
[dev:composables]     at /Users/karolszuster/Upside/vsf/tmp/spree/node_modules/rollup-plugin-typescript2/src/print-diagnostics.ts:41:11
[dev:composables]     at arrayEach (/Users/karolszuster/Upside/vsf/tmp/spree/node_modules/rollup-plugin-typescript2/node_modules/lodash/lodash.js:516:11)
[dev:composables]     at Function._.each [as forEach] (/Users/karolszuster/Upside/vsf/tmp/spree/node_modules/rollup-plugin-typescript2/node_modules/lodash/lodash.js:9368:14)
[dev:composables]     at printDiagnostics (/Users/karolszuster/Upside/vsf/tmp/spree/node_modules/rollup-plugin-typescript2/src/print-diagnostics.ts:9:2)
[dev:composables]     at Object.transform (/Users/karolszuster/Upside/vsf/tmp/spree/node_modules/rollup-plugin-typescript2/src/index.ts:244:5)
```
