### PR TITLE
fix: use Nuxt context properties in `Category.vue` page

### DIFF
--- a/packages/theme/pages/Category.vue
+++ b/packages/theme/pages/Category.vue
@@ -241,7 +241,7 @@ export default {
     const breadcrumbs = computed(() => facetGetters.getBreadcrumbs(result.value).map(e => ({...e, link: context.localePath(e.link)})));
     const pagination = computed(() => facetGetters.getPagination(result.value));
     const categoryTree = computed(() => facetGetters.getCategoryTree(result.value));
-    const { locale } = context.root.$i18n;
+    const { locale } = context.app.i18n;
 
     const getRoute = (category) => {
       if (menu.value.isDisabled) {
@@ -279,7 +279,7 @@ export default {
 
     onSSR(async () => {
       await search(th.getFacetsFromURL());
-      if (error?.value?.search) context.root.$nuxt.error({ statusCode: 404 });
+      if (error?.value?.search) context.app.nuxt.error({ statusCode: 404 });
     });
     return {
       ...uiState,


### PR DESCRIPTION
## Issue
```
TypeError
Cannot read property '$i18n' of undefined
```

## Cause
We are using the regular composition API context in some places (second argument of `setup()`) and the Nuxt one in other (`useContext()`). The Nuxt context does not contain `root`, the plugins are stored under `app`.

Changing the context in `Category.vue` to be the Vue one (second argument) causes Nuxt SSR errors so I stuck with `useContext` in this file.