### PR TITLE
fix: handle app footer when there is no menu configured

### DIFF
--- a/packages/theme/components/AppFooter.vue
+++ b/packages/theme/components/AppFooter.vue
@@ -103,7 +103,7 @@ export default {
     const menuSize = ref({});
     const { locale } = context.root.$i18n;
 
-    onMounted(() => menuSize.value = menu.value.items.length);
+    onMounted(() => menuSize.value = menu.value?.items?.length || 0);
 
     onSSR(async () => {
       await loadMenu({menuType: 'footer', menuName: 'Footer menu', locale: locale});


### PR DESCRIPTION
## Description
When adding dynamic menus to AppFooter recently, we missed a case when the footer isn't loaded instantly or is not configured in the backend. This shouldn't block the frontend from working.

## Motivation and Context
Fix issue with rendering pages.

## How Has This Been Tested?
Manual tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
