### PR TITLE
fix: resolve hydration error on HeaderNavigation and LocaleSelector

### DIFF
--- a/packages/theme/components/AppHeader.vue
+++ b/packages/theme/components/AppHeader.vue
@@ -12,7 +12,7 @@
         </a>
       </template>
       <template #navigation>
-        <HeaderNavigation :isMobile="isMobile" />
+        <HeaderNavigation />
       </template>
       <template #aside>
         <LocaleSelector class="smartphone-only" />

--- a/packages/theme/components/HeaderNavigation.vue
+++ b/packages/theme/components/HeaderNavigation.vue
@@ -1,62 +1,64 @@
 <template>
-  <div class="sf-header__navigation desktop" v-if="!isMobile">
-    <SfHeaderNavigationItem
-      v-for="(category, index) in categories"
-      :key="index"
-      class="nav-item"
-      v-e2e="`app-header-url_${category}`"
-      :label="category"
-      :link="localePath(`/c/categories/${category}`)"
-    />
-  </div>
-  <SfModal v-else-if="isCategoryTreeOrMenuAvailable" :visible="isMobileMenuOpen">
-    <SfAccordion open="" :multiple="false" transition="" showChevron>
-      <SfAccordionItem
-        v-for="(cat, i) in ((menu && menu.items) || (categoryTree && categoryTree.items))"
-        :key="i"
+  <div>
+    <div class="sf-header__navigation desktop-only">
+      <SfHeaderNavigationItem
+        v-for="(category, index) in categories"
+        :key="index"
         class="nav-item"
-        :header="cat.name || cat.label"
+        v-e2e="`app-header-url_${category}`"
+        :label="category"
+        :link="localePath(`/c/categories/${category}`)"
+      />
+    </div>
+    <SfModal v-if="isCategoryTreeOrMenuAvailable" :visible="isMobileMenuOpen">
+      <SfAccordion open="" :multiple="false" transition="" showChevron>
+        <SfAccordionItem
+          v-for="(cat, i) in ((menu && menu.items) || (categoryTree && categoryTree.items))"
+          :key="i"
+          class="nav-item"
+          :header="cat.name || cat.label"
+        >
+          <SfList>
+            <SfListItem>
+              <SfMenuItem
+                label="All"
+                class="sf-header-navigation-item__menu-item"
+                :link="localePath(getRoute(cat))"
+                @click.native="toggleMobileMenu"
+              />
+            </SfListItem>
+            <SfListItem
+              v-for="(subCat, j) in cat.items"
+              :key="j">
+              <SfMenuItem
+                :label="subCat.name || subCat.label"
+                class="sf-header-navigation-item__menu-item"
+                :link="localePath(getRoute(subCat))"
+                @click.native="toggleMobileMenu"
+              />
+            </SfListItem>
+          </SfList>
+        </SfAccordionItem>
+      </SfAccordion>
+    </SfModal>
+    <SfModal v-else :visible="isMobileMenuOpen">
+      <SfHeaderNavigationItem
+        v-for="(category, index) in categories"
+        :key="index"
+        class="nav-item"
+        v-e2e="`app-header-url_${category}`"
       >
-        <SfList>
-          <SfListItem>
-            <SfMenuItem
-              label="All"
-              class="sf-header-navigation-item__menu-item"
-              :link="localePath(getRoute(cat))"
-              @click.native="toggleMobileMenu"
-            />
-          </SfListItem>
-          <SfListItem
-            v-for="(subCat, j) in cat.items"
-            :key="j">
-            <SfMenuItem
-              :label="subCat.name || subCat.label"
-              class="sf-header-navigation-item__menu-item"
-              :link="localePath(getRoute(subCat))"
-              @click.native="toggleMobileMenu"
-            />
-          </SfListItem>
-        </SfList>
-      </SfAccordionItem>
-    </SfAccordion>
-  </SfModal>
-  <SfModal v-else :visible="isMobileMenuOpen">
-    <SfHeaderNavigationItem
-      v-for="(category, index) in categories"
-      :key="index"
-      class="nav-item"
-      v-e2e="`app-header-url_${category}`"
-    >
-      <template #mobile-navigation-item>
-        <SfMenuItem
-          :label="category"
-          class="sf-header-navigation-item__menu-item"
-          :link="localePath(`/c/categories/${category}`)"
-          @click.native="toggleMobileMenu"
-        />
-      </template>
-    </SfHeaderNavigationItem>
-  </SfModal>
+        <template #mobile-navigation-item>
+          <SfMenuItem
+            :label="category"
+            class="sf-header-navigation-item__menu-item"
+            :link="localePath(`/c/categories/${category}`)"
+            @click.native="toggleMobileMenu"
+          />
+        </template>
+      </SfHeaderNavigationItem>
+    </SfModal>
+  </div>
 </template>
 
 <script>

--- a/packages/theme/components/HeaderNavigation.vue
+++ b/packages/theme/components/HeaderNavigation.vue
@@ -76,12 +76,6 @@ export default {
     SfAccordion,
     SfList
   },
-  props: {
-    isMobile: {
-      type: Boolean,
-      default: false
-    }
-  },
   setup(props, context) {
     const { result } = useFacet();
     const { isMobileMenuOpen, toggleMobileMenu } = useUiState();

--- a/packages/theme/components/LocaleSelector.vue
+++ b/packages/theme/components/LocaleSelector.vue
@@ -63,7 +63,7 @@
           <SfListItem v-for="currency in allCurrencies" :key="currency.code">
             <SfButton
               class="sf-button sf-button--pure container__action"
-              @click="handleChangeCurrencyClick(currency.code, currency.locale)"
+              @click="handleChangeCurrencyClick(currency.code)"
               :class="{
                 'container__action--selected': isCurrencySelected(currency)
               }"
@@ -84,13 +84,10 @@
     <div class="locale-selector locale-selector--desktop desktop-only">
       <SfDropdown
         :isOpen="isLocaleModalOpen"
-        :persistent="false"
+        persistent
         class="locale-selector__container container container--locale"
         @click:close="closeLocaleSelector()"
       >
-        <template #cancel>
-          <span />
-        </template>
         <template #title>
           <p class="sf-dropdown__title container__label container__label--hint">
             {{ $t('Change locale') }}
@@ -146,13 +143,10 @@
       </SfDropdown>
       <SfDropdown
         :isOpen="isCurrencyModalOpen"
-        :persistent="false"
+        persistent
         class="locale-selector__container container container--currency"
         @click:close="closeCurrencySelector()"
       >
-        <template #cancel>
-          <span />
-        </template>
         <template #title>
           <p class="sf-dropdown__title container__label container__label--hint">
             {{ $t('Change currency') }}
@@ -177,7 +171,7 @@
           <SfListItem v-for="currency in allCurrencies" :key="currency.code">
             <SfButton
               class="sf-button sf-button--pure container__action"
-              @click="handleChangeCurrencyClick(currency.code, currency.locale)"
+              @click="handleChangeCurrencyClick(currency.code)"
               :class="{
                 'container__action--selected': isCurrencySelected(currency)
               }"
@@ -211,10 +205,6 @@ import {
 import { ref, computed, onBeforeUnmount } from '@nuxtjs/composition-api';
 import { useVSFContext } from '@vue-storefront/core';
 import { VSF_SPREE_CURRENCY_COOKIE } from '@vue-storefront/spree-api';
-import {
-  mapMobileObserver,
-  unMapMobileObserver
-} from '@storefront-ui/vue/src/utilities/mobile-observer.js';
 export default {
   components: {
     SfImage,
@@ -231,7 +221,6 @@ export default {
 
     const isLocaleModalOpen = ref(false);
     const isCurrencyModalOpen = ref(false);
-    const isMobile = computed(mapMobileObserver().isMobile);
 
     const { locales: allLocales, locale, numberFormats } = root.$i18n;
     const allCurrencies = computed(() =>
@@ -279,10 +268,6 @@ export default {
       window.location.reload();
     };
 
-    onBeforeUnmount(() => {
-      unMapMobileObserver();
-    });
-
     return {
       allLocales,
       allCurrencies,
@@ -291,7 +276,6 @@ export default {
       isLocaleModalOpen,
       isCurrencyModalOpen,
       handleChangeCurrencyClick,
-      isMobile,
       openLocaleSelector,
       closeLocaleSelector,
       openCurrencySelector,

--- a/packages/theme/components/LocaleSelector.vue
+++ b/packages/theme/components/LocaleSelector.vue
@@ -202,7 +202,7 @@ import {
   SfCharacteristic,
   SfDropdown
 } from '@storefront-ui/vue';
-import { ref, computed, onBeforeUnmount } from '@nuxtjs/composition-api';
+import { ref, computed } from '@nuxtjs/composition-api';
 import { useVSFContext } from '@vue-storefront/core';
 import { VSF_SPREE_CURRENCY_COOKIE } from '@vue-storefront/spree-api';
 export default {

--- a/packages/theme/components/LocaleSelector.vue
+++ b/packages/theme/components/LocaleSelector.vue
@@ -1,39 +1,114 @@
 <template>
-  <div class="locale-selector locale-selector--mobile" v-if="isMobile">
-    <SfButton
-      data-cy="locale-select_change-locale"
-      class="sf-button sf-button--pure locale-selector__opener locale-selector__opener--locale locale-selector__opener--selected"
-      @click="openLocaleSelector()"
-    >
-      <img
-        :src="
-          `https://cdn.shopify.com/s/files/1/0407/1902/4288/files/${locale}_20x20.jpg`
-        "
-        width="20"
-        height="20"
-      />
-    </SfButton>
-    <SfBottomModal
-      :is-open="isLocaleModalOpen"
-      :title="$t('Change locale')"
-      @click:close="closeLocaleSelector()"
-      class="locale-selector__container container container--locale"
-    >
-      <SfList>
-        <SfListItem v-for="locale in allLocales" :key="locale.code">
-          <nuxt-link
-            :to="switchLocalePath(locale.code)"
-            class="container__action"
-            :class="{ 'container__action--selected': isLocaleSelected(locale) }"
+  <div>
+    <div class="locale-selector locale-selector--mobile smartphone-only">
+      <SfButton
+        data-cy="locale-select_change-locale"
+        class="sf-button sf-button--pure locale-selector__opener locale-selector__opener--locale locale-selector__opener--selected"
+        @click="openLocaleSelector()"
+      >
+        <img
+          :src="
+            `https://cdn.shopify.com/s/files/1/0407/1902/4288/files/${locale}_20x20.jpg`
+          "
+          width="20"
+          height="20"
+        />
+      </SfButton>
+      <SfBottomModal
+        :is-open="isLocaleModalOpen"
+        :title="$t('Change locale')"
+        @click:close="closeLocaleSelector()"
+        class="locale-selector__container container container--locale"
+      >
+        <SfList>
+          <SfListItem v-for="locale in allLocales" :key="locale.code">
+            <nuxt-link
+              :to="switchLocalePath(locale.code)"
+              class="container__action"
+              :class="{ 'container__action--selected': isLocaleSelected(locale) }"
+            >
+              <SfCharacteristic class="container__characteristic">
+                <template #title>
+                  <span class="container__label">{{ locale.label }}</span>
+                </template>
+                <template #icon>
+                  <img
+                    :src="
+                      `https://cdn.shopify.com/s/files/1/0407/1902/4288/files/${locale.code}_20x20.jpg`
+                    "
+                    class="container__icon"
+                    width="20"
+                    height="20"
+                  />
+                </template>
+              </SfCharacteristic>
+            </nuxt-link>
+          </SfListItem>
+        </SfList>
+      </SfBottomModal>
+      <SfButton
+        data-cy="locale-select_change-currency"
+        class="sf-button sf-button--pure locale-selector__opener locale-selector__opener--currency locale-selector__opener--selected"
+        @click="openCurrencySelector()"
+      >
+        {{ currency }}
+      </SfButton>
+      <SfBottomModal
+        :is-open="isCurrencyModalOpen"
+        :title="$t('Change currency')"
+        @click:close="closeCurrencySelector()"
+        class="locale-selector__container container container--currency"
+      >
+        <SfList>
+          <SfListItem v-for="currency in allCurrencies" :key="currency.code">
+            <SfButton
+              class="sf-button sf-button--pure container__action"
+              @click="handleChangeCurrencyClick(currency.code, currency.locale)"
+              :class="{
+                'container__action--selected': isCurrencySelected(currency)
+              }"
+            >
+              <SfCharacteristic class="container__characteristic">
+                <template #title>
+                  <span class="container__label">{{ currency.code }}</span>
+                </template>
+                <template #icon>
+                  <span />
+                </template>
+              </SfCharacteristic>
+            </SfButton>
+          </SfListItem>
+        </SfList>
+      </SfBottomModal>
+    </div>
+    <div class="locale-selector locale-selector--desktop desktop-only">
+      <SfDropdown
+        :isOpen="isLocaleModalOpen"
+        :persistent="false"
+        class="locale-selector__container container container--locale"
+        @click:close="closeLocaleSelector()"
+      >
+        <template #cancel>
+          <span />
+        </template>
+        <template #title>
+          <p class="sf-dropdown__title container__label container__label--hint">
+            {{ $t('Change locale') }}
+          </p>
+        </template>
+        <template #opener>
+          <SfButton
+            @click="openLocaleSelector()"
+            class="sf-button sf-button--pure container__opener"
           >
             <SfCharacteristic class="container__characteristic">
               <template #title>
-                <span class="container__label">{{ locale.label }}</span>
+                <span />
               </template>
               <template #icon>
                 <img
                   :src="
-                    `https://cdn.shopify.com/s/files/1/0407/1902/4288/files/${locale.code}_20x20.jpg`
+                    `https://cdn.shopify.com/s/files/1/0407/1902/4288/files/${locale}_20x20.jpg`
                   "
                   class="container__icon"
                   width="20"
@@ -41,158 +116,85 @@
                 />
               </template>
             </SfCharacteristic>
-          </nuxt-link>
-        </SfListItem>
-      </SfList>
-    </SfBottomModal>
-    <SfButton
-      data-cy="locale-select_change-currency"
-      class="sf-button sf-button--pure locale-selector__opener locale-selector__opener--currency locale-selector__opener--selected"
-      @click="openCurrencySelector()"
-    >
-      {{ currency }}
-    </SfButton>
-    <SfBottomModal
-      :is-open="isCurrencyModalOpen"
-      :title="$t('Change currency')"
-      @click:close="closeCurrencySelector()"
-      class="locale-selector__container container container--currency"
-    >
-      <SfList>
-        <SfListItem v-for="currency in allCurrencies" :key="currency.code">
+          </SfButton>
+        </template>
+        <SfList>
+          <SfListItem v-for="locale in allLocales" :key="locale.code">
+            <nuxt-link
+              :to="switchLocalePath(locale.code)"
+              class="container__action"
+              :class="{ 'container__action--selected': isLocaleSelected(locale) }"
+            >
+              <SfCharacteristic class="container__characteristic">
+                <template #title>
+                  <span class="container__label">{{ locale.label }}</span>
+                </template>
+                <template #icon>
+                  <img
+                    :src="
+                      `https://cdn.shopify.com/s/files/1/0407/1902/4288/files/${locale.code}_20x20.jpg`
+                    "
+                    class="container__icon"
+                    width="20"
+                    height="20"
+                  />
+                </template>
+              </SfCharacteristic>
+            </nuxt-link>
+          </SfListItem>
+        </SfList>
+      </SfDropdown>
+      <SfDropdown
+        :isOpen="isCurrencyModalOpen"
+        :persistent="false"
+        class="locale-selector__container container container--currency"
+        @click:close="closeCurrencySelector()"
+      >
+        <template #cancel>
+          <span />
+        </template>
+        <template #title>
+          <p class="sf-dropdown__title container__label container__label--hint">
+            {{ $t('Change currency') }}
+          </p>
+        </template>
+        <template #opener>
           <SfButton
-            class="sf-button sf-button--pure container__action"
-            @click="handleChangeCurrencyClick(currency.code, currency.locale)"
-            :class="{
-              'container__action--selected': isCurrencySelected(currency)
-            }"
+            @click="openCurrencySelector()"
+            class="sf-button sf-button--pure container__opener"
           >
             <SfCharacteristic class="container__characteristic">
               <template #title>
-                <span class="container__label">{{ currency.code }}</span>
+                <span class="container__label">{{ currency }}</span>
               </template>
               <template #icon>
                 <span />
               </template>
             </SfCharacteristic>
           </SfButton>
-        </SfListItem>
-      </SfList>
-    </SfBottomModal>
-  </div>
-  <div class="locale-selector locale-selector--desktop" v-else>
-    <SfDropdown
-      :isOpen="isLocaleModalOpen"
-      :persistent="false"
-      class="locale-selector__container container container--locale"
-      @click:close="closeLocaleSelector()"
-    >
-      <template #cancel>
-        <span />
-      </template>
-      <template #title>
-        <p class="sf-dropdown__title container__label container__label--hint">
-          {{ $t('Change locale') }}
-        </p>
-      </template>
-      <template #opener>
-        <SfButton
-          @click="openLocaleSelector()"
-          class="sf-button sf-button--pure container__opener"
-        >
-          <SfCharacteristic class="container__characteristic">
-            <template #title>
-              <span />
-            </template>
-            <template #icon>
-              <img
-                :src="
-                  `https://cdn.shopify.com/s/files/1/0407/1902/4288/files/${locale}_20x20.jpg`
-                "
-                class="container__icon"
-                width="20"
-                height="20"
-              />
-            </template>
-          </SfCharacteristic>
-        </SfButton>
-      </template>
-      <SfList>
-        <SfListItem v-for="locale in allLocales" :key="locale.code">
-          <nuxt-link
-            :to="switchLocalePath(locale.code)"
-            class="container__action"
-            :class="{ 'container__action--selected': isLocaleSelected(locale) }"
-          >
-            <SfCharacteristic class="container__characteristic">
-              <template #title>
-                <span class="container__label">{{ locale.label }}</span>
-              </template>
-              <template #icon>
-                <img
-                  :src="
-                    `https://cdn.shopify.com/s/files/1/0407/1902/4288/files/${locale.code}_20x20.jpg`
-                  "
-                  class="container__icon"
-                  width="20"
-                  height="20"
-                />
-              </template>
-            </SfCharacteristic>
-          </nuxt-link>
-        </SfListItem>
-      </SfList>
-    </SfDropdown>
-    <SfDropdown
-      :isOpen="isCurrencyModalOpen"
-      :persistent="false"
-      class="locale-selector__container container container--currency"
-      @click:close="closeCurrencySelector()"
-    >
-      <template #cancel>
-        <span />
-      </template>
-      <template #title>
-        <p class="sf-dropdown__title container__label container__label--hint">
-          {{ $t('Change currency') }}
-        </p>
-      </template>
-      <template #opener>
-        <SfButton
-          @click="openCurrencySelector()"
-          class="sf-button sf-button--pure container__opener"
-        >
-          <SfCharacteristic class="container__characteristic">
-            <template #title>
-              <span class="container__label">{{ currency }}</span>
-            </template>
-            <template #icon>
-              <span />
-            </template>
-          </SfCharacteristic>
-        </SfButton>
-      </template>
-      <SfList>
-        <SfListItem v-for="currency in allCurrencies" :key="currency.code">
-          <SfButton
-            class="sf-button sf-button--pure container__action"
-            @click="handleChangeCurrencyClick(currency.code, currency.locale)"
-            :class="{
-              'container__action--selected': isCurrencySelected(currency)
-            }"
-          >
-            <SfCharacteristic class="container__characteristic">
-              <template #title>
-                <span class="container__label">{{ currency.code }}</span>
-              </template>
-              <template #icon>
-                <span />
-              </template>
-            </SfCharacteristic>
-          </SfButton>
-        </SfListItem>
-      </SfList>
-    </SfDropdown>
+        </template>
+        <SfList>
+          <SfListItem v-for="currency in allCurrencies" :key="currency.code">
+            <SfButton
+              class="sf-button sf-button--pure container__action"
+              @click="handleChangeCurrencyClick(currency.code, currency.locale)"
+              :class="{
+                'container__action--selected': isCurrencySelected(currency)
+              }"
+            >
+              <SfCharacteristic class="container__characteristic">
+                <template #title>
+                  <span class="container__label">{{ currency.code }}</span>
+                </template>
+                <template #icon>
+                  <span />
+                </template>
+              </SfCharacteristic>
+            </SfButton>
+          </SfListItem>
+        </SfList>
+      </SfDropdown>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
## Description
Updates to HeaderNavigation and LocaleSelector to resolve hydration errors when loading on mobile. This involves removing the use of v-if directives using 'isMobile' and instead using "desktop-only" and "smartphone-only" classes, as isMobile is undefined on the server-side. Also added a root div.

## Related Issue
Per issue #241 

## Motivation and Context
Hydration error as noted in issue.

## How Has This Been Tested?
Tested locally on Chrome. Updates resolve the hydration error.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
