### PR TITLE
fix: update broken link to vue storefront documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The monorepo contains three submodules:
 - composables - reusable business logic
 - theme - Nuxt.js-based frontend application
 
-For more details, refer to the official [architecture diagram](https://docs.vuestorefront.io/v2/advanced/architecture.html).
+For more details, refer to the official [project structure](https://docs.vuestorefront.io/v2/getting-started/project-structure.html).
 
 ## Feature support
 


### PR DESCRIPTION
## Description
Update broken link in Readme to Vue Storefront documentation.

## Related Issue
#240 

## Motivation and Context
Keep documentation up to date.

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
