### PR TITLE
feat: add ability to skip billing step

### DIFF
--- a/packages/theme/components/Checkout/VsfShippingProvider.vue
+++ b/packages/theme/components/Checkout/VsfShippingProvider.vue
@@ -24,7 +24,7 @@
           type="button"
           @click="save"
         >
-          {{ $t('Continue to billing') }}
+          {{ $t(buttonText) }}
         </SfButton>
       </div>
   </div>
@@ -40,7 +40,12 @@ import ShippingRatePicker from '~/components/Checkout/ShippingRatePicker.vue';
 
 export default {
   name: 'VsfShippingProvider',
-
+  props: {
+    buttonText: {
+      type: String,
+      required: true
+    },
+  },
   components: {
     SfButton,
     ShippingRatePicker

--- a/packages/theme/components/Checkout/VsfShippingProvider.vue
+++ b/packages/theme/components/Checkout/VsfShippingProvider.vue
@@ -44,7 +44,7 @@ export default {
     buttonText: {
       type: String,
       required: true
-    },
+    }
   },
   components: {
     SfButton,

--- a/packages/theme/pages/Checkout/Shipping.vue
+++ b/packages/theme/pages/Checkout/Shipping.vue
@@ -231,7 +231,7 @@
             infoMessage=""
             errorMessage=""
             valid
-            :disabled="false"
+            :disabled="isFormSubmitted"
             v-model="isCopyToBillingSelected"
           />
         </div>
@@ -248,8 +248,9 @@
       </div>
       <VsfShippingProvider
         v-if="isFormSubmitted"
-        @submit="router.push(localePath({ name: 'billing' }))"
+        @submit="routeToBillingOrPayment()"
         @back="() => isFormSubmitted = !isFormSubmitted"
+        :buttonText="buttonText"
       />
     </form>
   </ValidationObserver>
@@ -302,6 +303,7 @@ export default {
     const isFormSubmitted = ref(false);
     const isSaveAddressSelected = ref(false);
     const isCopyToBillingSelected = ref(true);
+    const buttonText = ref(null);
     const { countries, states, load: loadCountries, loadStates } = useCountry();
     const { shipping: checkoutShippingAddress, load, save, loading } = useShipping();
     const { shipping: savedAddresses, load: loadSavedAddresses, addAddress } = useUserShipping();
@@ -350,7 +352,10 @@ export default {
 
       await save({ shippingDetails: shippingAddress });
       if (isCopyToBillingSelected.value) {
+        buttonText.value = 'Continue to payment';
         await billing.save({ billingDetails: shippingAddress });
+      } else {
+        buttonText.value = 'Continue to billing';
       }
 
       if (isSaveAddressSelected.value) {
@@ -369,6 +374,14 @@ export default {
     const populateSelectedAddressId = () => {
       if (checkoutShippingAddress.value && savedAddresses.value?.addresses) {
         selectedSavedAddressId.value = savedAddresses.value.addresses.find(e => isEqualAddress(e, checkoutShippingAddress.value))?._id;
+      }
+    };
+
+    const routeToBillingOrPayment = () => {
+      if (isCopyToBillingSelected.value) {
+        router.push('/checkout/payment');
+      } else {
+        router.push('/checkout/billing');
       }
     };
 
@@ -426,7 +439,9 @@ export default {
       checkoutShippingAddress,
       handleFormSubmit,
       isCopyToBillingSelected,
-      getBackToShippingDetails
+      getBackToShippingDetails,
+      routeToBillingOrPayment,
+      buttonText
     };
   }
 };


### PR DESCRIPTION
## Description
When the user selects the "use the same details for billing" and selects their shipping method on the shipping page, the user should be able to skip the "billing address" page and go directly to the payment page (as the billing address has already been saved).

## Related Issue
#245 

## Motivation and Context
Improved user experience. Less checkout steps = Higher conversion rate.

## How Has This Been Tested?
Tested locally on chrome.

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
