### PR TITLE
feat: remove product id from url

### DIFF
--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -200,8 +200,20 @@ export default {
         path: '/my-account/:pageName/:id?',
         component: resolve(__dirname, 'pages/MyAccount.vue')
       });
-      const index = routes.findIndex(route => route.path === "/Product");
-      routes[index].path = "/products/:slug/";
+      
+      // Delete OOB product route
+      routes.splice(
+        routes.findIndex(route => route.path === '/Product'),
+        1
+      );
+
+      // Re-register the product route with different path
+      routes.push({
+        name: 'Product',
+        path: '/products/:slug/',
+        component: resolve(__dirname, '_theme/pages/Product.vue'),
+        chunkName: '_theme/pages/Product'
+      });
     }
   },
   publicRuntimeConfig: {

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -200,6 +200,8 @@ export default {
         path: '/my-account/:pageName/:id?',
         component: resolve(__dirname, 'pages/MyAccount.vue')
       });
+      const index = routes.findIndex(route => route.path === "/Product");
+      routes[index].path = "/products/:slug/";
     }
   },
   publicRuntimeConfig: {

--- a/packages/theme/pages/Category.vue
+++ b/packages/theme/pages/Category.vue
@@ -97,7 +97,7 @@
               :add-to-cart-disabled="!productGetters.getInStock(product)"
               :is-in-wishlist="isInWishlist({ product })"
               :is-added-to-cart="isInCart({ product })"
-              :link="localePath(`/p/${productGetters.getId(product)}/${productGetters.getSlug(product)}`)"
+              :link="localePath(`/products/${productGetters.getSlug(product)}`)"
               :wishlist-icon="isWishlistDisabled ? false : undefined"
               class="products__product-card"
               @click:wishlist="handleWishlistClick(product)"
@@ -123,7 +123,7 @@
               :regular-price="$n(productGetters.getPrice(product).regular, 'currency')"
               :special-price="productGetters.getPrice(product).special && $n(productGetters.getPrice(product).special, 'currency')"
               :is-in-wishlist="isInWishlist({ product })"
-              :link="localePath(`/p/${productGetters.getId(product)}/${productGetters.getSlug(product)}`)"
+              :link="localePath(`/products/${productGetters.getSlug(product)}`)"
               @click:wishlist="handleWishlistClick(product)"
               @click:add-to-cart="addItemToCart({ product, quantity: 1 })"
             >


### PR DESCRIPTION
## Description
As noted in issue, products IDs currently in the URL are redundant. 
This PR updates the routing to remove them from the product URLs.
My preference would be for the default to be `/products/:slug` (rather than `/p/:slug`), as this has been the default for Spree stores in the past (and keeping this will be better for SEO, and reduce the need for redirects). Thoughts?

## Related Issue
#221 

## Motivation and Context
To simplify URL and remove extra integration steps.

## How Has This Been Tested?
Tested locally on Chrome 103.0.5060.114

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.