### PR TITLE
feat: localize validation errors

### DIFF
--- a/packages/theme/components/LoginModal.vue
+++ b/packages/theme/components/LoginModal.vue
@@ -201,16 +201,6 @@ import { required, email } from 'vee-validate/dist/rules';
 import { useUiState } from '~/composables';
 import { useUser, useForgotPassword } from '@vue-storefront/spree';
 
-extend('email', {
-  ...email,
-  message: 'Invalid email'
-});
-
-extend('required', {
-  ...required,
-  message: 'This field is required'
-});
-
 export default {
   name: 'LoginModal',
   components: {
@@ -223,6 +213,16 @@ export default {
     ValidationProvider,
     ValidationObserver,
     SfBar
+  },
+  created() {
+    extend('required', {
+      ...required,
+      message: this.$i18n.t('shared.validation.required')
+    });
+    extend('email', {
+      ...email,
+      message: this.$i18n.t('shared.validation.email')
+    });
   },
   setup(_root, context) {
     const SCREEN_LOGIN = 'login';

--- a/packages/theme/components/MyAccount/PasswordResetForm.vue
+++ b/packages/theme/components/MyAccount/PasswordResetForm.vue
@@ -55,29 +55,13 @@ import {
   SfButton,
   SfSelect
 } from '@storefront-ui/vue';
-import {required, confirmed} from 'vee-validate/dist/rules';
+import { required, confirmed } from 'vee-validate/dist/rules';
 import { ValidationProvider, ValidationObserver, extend } from 'vee-validate';
 import { reactive} from '@nuxtjs/composition-api';
 import { useUser } from '@vue-storefront/spree';
 
-extend('required', {
-  ...required,
-  message: 'This field is required'
-});
-
-extend('password', {
-  validate: value => String(value).length >= 8 && String(value).match(/[A-Za-z]/gi) && String(value).match(/[0-9]/gi),
-  message: 'Password must have at least 8 characters including one letter and a number'
-});
-
-extend('confirmed', {
-  ...confirmed,
-  message: 'Passwords don\'t match'
-});
-
 export default {
   name: 'PasswordResetForm',
-
   components: {
     SfInput,
     SfButton,
@@ -85,7 +69,6 @@ export default {
     ValidationProvider,
     ValidationObserver
   },
-
   password: {
     type: Object,
     default: () => ({
@@ -93,7 +76,20 @@ export default {
       newPasswordConfirmation: ''
     })
   },
-
+  created() {
+    extend('required', {
+      ...required,
+      message: this.$i18n.t('shared.validation.required')
+    });
+    extend('password', {
+      validate: value => String(value).length >= 8 && String(value).match(/[A-Za-z]/gi) && String(value).match(/[0-9]/gi),
+      message: this.$i18n.t('shared.validation.password.min_characters_letter_number', { minCharacters: 8 })
+    });
+    extend('confirmed', {
+      ...confirmed,
+      message: this.$i18n.t('shared.validation.confirmed.passwords')
+    });
+  },
   setup(password) {
     const { changePassword} = useUser();
     const form = reactive({

--- a/packages/theme/components/MyAccount/SavedAddressForm.vue
+++ b/packages/theme/components/MyAccount/SavedAddressForm.vue
@@ -184,24 +184,8 @@ import { reactive, watch, computed, onMounted } from '@nuxtjs/composition-api';
 import { onSSR } from '@vue-storefront/core';
 import { useCountry } from '@vue-storefront/spree';
 
-extend('required', {
-  ...required,
-  message: 'This field is required'
-});
-
-extend('min', {
-  ...min,
-  message: 'The field should have at least {length} characters'
-});
-
-extend('oneOf', {
-  ...oneOf,
-  message: 'Invalid country'
-});
-
 export default {
   name: 'SavedAddressForm',
-
   components: {
     SfInput,
     SfButton,
@@ -210,7 +194,6 @@ export default {
     ValidationProvider,
     ValidationObserver
   },
-
   props: {
     address: {
       type: Object,
@@ -233,7 +216,20 @@ export default {
       required: true
     }
   },
-
+  created() {
+    extend('required', {
+      ...required,
+      message: this.$i18n.t('shared.validation.required')
+    });
+    extend('min', {
+      ...min,
+      message: this.$i18n.t('shared.validation.min')
+    });
+    extend('oneOf', {
+      ...oneOf,
+      message: this.$i18n.t('shared.validation.one_of.country')
+    });
+  },
   setup(props, { emit }) {
     const { countries, states, load: loadCountries, loadStates } = useCountry();
     const form = reactive({

--- a/packages/theme/lang/de.js
+++ b/packages/theme/lang/de.js
@@ -1,5 +1,22 @@
 export default {
   shared: {
+    validation: {
+      email: 'Bitte geben Sie eine gültige E-Mail Adresse an',
+      required: 'Dieses Feld ist erforderlich',
+      password: {
+        min_characters_letter_number: 'Das Passwort muss mindestens {minCharacters} Zeichen lang sein, darunter ein Buchstabe und eine Zahl'
+      },
+      confirmed: {
+        passwords: 'Passwörter stimmen nicht überein'
+      },
+      min: 'Dieses Feld sollte mindestens {length} Zeichen haben',
+      one_of: {
+        country: 'Ungültiges Land'
+      },
+      digits: {
+        phone_number: 'Geben Sie bitte eine gültige Telephonnummer an'
+      }
+    },
     form: {
       email: 'Email',
       first_name: 'Vorname',

--- a/packages/theme/lang/en.js
+++ b/packages/theme/lang/en.js
@@ -1,5 +1,22 @@
 export default {
   shared: {
+    validation: {
+      email: 'Please, provide a valid email address',
+      required: 'This field is required',
+      password: {
+        min_characters_letter_number: 'Password must have at least {minCharacters} characters including one letter and a number'
+      },
+      confirmed: {
+        passwords: 'Passwords don\'t match'
+      },
+      min: 'This field should have at least {length} characters',
+      one_of: {
+        country: 'Invalid country'
+      },
+      digits: {
+        phone_number: 'Please, provide a valid phone number'
+      }
+    },
     form: {
       email: 'Email',
       first_name: 'First Name',

--- a/packages/theme/pages/Checkout/Billing.vue
+++ b/packages/theme/pages/Checkout/Billing.vue
@@ -213,19 +213,6 @@ import { ValidationProvider, ValidationObserver, extend } from 'vee-validate';
 import AddressPicker from '~/components/Checkout/AddressPicker';
 import _ from 'lodash';
 
-extend('required', {
-  ...required,
-  message: 'This field is required'
-});
-extend('min', {
-  ...min,
-  message: 'The field should have at least {length} characters'
-});
-extend('digits', {
-  ...digits,
-  message: 'Please provide a valid phone number'
-});
-
 export default {
   name: 'Billing',
   components: {
@@ -238,6 +225,20 @@ export default {
     AddressPicker,
     ValidationProvider,
     ValidationObserver
+  },
+  created() {
+    extend('required', {
+      ...required,
+      message: this.$i18n.t('shared.validation.required')
+    });
+    extend('min', {
+      ...min,
+      message: this.$i18n.t('shared.validation.min')
+    });
+    extend('digits', {
+      ...digits,
+      message: this.$i18n.t('shared.validation.digits.phone_number')
+    });
   },
   setup(_props, { root }) {
     const { billing: checkoutBillingAddress, load, save } = useBilling();

--- a/packages/theme/pages/Checkout/Shipping.vue
+++ b/packages/theme/pages/Checkout/Shipping.vue
@@ -272,19 +272,6 @@ import { ValidationProvider, ValidationObserver, extend } from 'vee-validate';
 import AddressPicker from '~/components/Checkout/AddressPicker';
 import _ from 'lodash';
 
-extend('required', {
-  ...required,
-  message: 'This field is required'
-});
-extend('min', {
-  ...min,
-  message: 'The field should have at least {length} characters'
-});
-extend('digits', {
-  ...digits,
-  message: 'Please provide a valid phone number'
-});
-
 export default {
   name: 'Shipping',
   components: {
@@ -297,6 +284,20 @@ export default {
     ValidationProvider,
     ValidationObserver,
     VsfShippingProvider: () => import('~/components/Checkout/VsfShippingProvider')
+  },
+  created() {
+    extend('required', {
+      ...required,
+      message: this.$i18n.t('shared.validation.required')
+    });
+    extend('min', {
+      ...min,
+      message: this.$i18n.t('shared.validation.min')
+    });
+    extend('digits', {
+      ...digits,
+      message: this.$i18n.t('shared.validation.digits.phone_number')
+    });
   },
   setup () {
     const router = useRouter();

--- a/packages/theme/pages/ResetPassword.vue
+++ b/packages/theme/pages/ResetPassword.vue
@@ -70,12 +70,6 @@ import { useForgotPassword, forgotPasswordGetters } from '@vue-storefront/spree'
 import { ValidationProvider, ValidationObserver, extend } from 'vee-validate';
 import { required } from 'vee-validate/dist/rules';
 
-// TODO: change validation msgs
-extend('required', {
-  ...required,
-  message: 'This field is required'
-});
-
 export default {
   name: 'ResetPassword',
   layout: 'blank',
@@ -92,6 +86,12 @@ export default {
     SfInput,
     ValidationProvider,
     ValidationObserver
+  },
+  created() {
+    extend('required', {
+      ...required,
+      message: this.$i18n.t('shared.validation.required')
+    });
   },
   setup() {
     const route = useRoute();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With this commit, vee-validate extended error messages are now localized.

## Description
<!--- Describe your changes in detail -->
Moved all extend(...) vee-validate function calls into created() method and used i18n to localize messages.
 
Messages are localized for global scope, not component/page specific. This is done, to achieve consistency across different forms.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/vuestorefront/spree/pull/249

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Providing full internationalization support.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
