### PR TITLE
feat: add header menu cms support

### DIFF
--- a/packages/theme/pages/Category.vue
+++ b/packages/theme/pages/Category.vue
@@ -28,7 +28,7 @@
               :show-chevron="true"
             >
               <SfAccordionItem
-                v-for="(cat, i) in ((menu && menu.items) || (categoryTree && categoryTree.items))"
+                v-for="(cat, i) in (categoryTree && categoryTree.items)"
                 :key="i"
                 :header="cat.name || cat.label"
               >
@@ -213,8 +213,8 @@ import {
   SfColor,
   SfProperty
 } from '@storefront-ui/vue';
-import { computed, onMounted, useContext } from '@nuxtjs/composition-api';
-import { useCart, useWishlist, productGetters, useFacet, facetGetters, useUser, wishlistGetters, useMenus } from '@vue-storefront/spree';
+import { computed, useContext } from '@nuxtjs/composition-api';
+import { useCart, useWishlist, productGetters, useFacet, facetGetters, useUser, wishlistGetters } from '@vue-storefront/spree';
 import { useUiHelpers, useUiState } from '~/composables';
 import { onSSR } from '@vue-storefront/core';
 import LazyHydrate from 'vue-lazy-hydration';
@@ -236,19 +236,14 @@ export default {
     const { result, search, loading, error } = useFacet();
     const { wishlist, addItem: addItemToWishlist, isInWishlist, removeItem: removeItemFromWishlist } = useWishlist();
     const { isAuthenticated } = useUser();
-    const { menu, loadMenu } = useMenus('header');
     const products = computed(() => facetGetters.getProducts(result.value));
     const breadcrumbs = computed(() => facetGetters.getBreadcrumbs(result.value).map(e => ({...e, link: context.localePath(e.link)})));
     const pagination = computed(() => facetGetters.getPagination(result.value));
     const categoryTree = computed(() => facetGetters.getCategoryTree(result.value));
-    const { locale } = context.app.i18n;
 
     const getRoute = (category) => {
-      const slugBasedRoute = `/c/${category.slug}`;
-      if (menu.value.isDisabled) {
-        return slugBasedRoute;
-      }
-      return category.link || slugBasedRoute;
+      if (category.slug) return `/c/${category.slug}`;
+      return '';
     };
 
     const activeCategory = computed(() => {
@@ -274,10 +269,6 @@ export default {
       }
     };
 
-    onMounted(async () => {
-      await loadMenu({menuType: 'header', menuName: 'Main menu', locale: locale});
-    });
-
     onSSR(async () => {
       await search(th.getFacetsFromURL());
       if (error?.value?.search) context.app.nuxt.error({ statusCode: 404 });
@@ -297,8 +288,7 @@ export default {
       isInCart,
       handleWishlistClick,
       isWishlistDisabled,
-      getRoute,
-      menu
+      getRoute
     };
   },
   components: {


### PR DESCRIPTION
This PR adds basic support for spree menu configuration.

## Description
In order for the menu to work it has to be enabled in `middleware.config.js`. By default the `HeaderNavigation` will try to render the Main Menu or spree category tree. If they are not available it will fall back to a hard-coded array of navigation items.

Additionally the Category picker is now rendering items only from the spree categories taxonomy.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
