### PR TITLE
feat: revert the api fetcher import

### DIFF
--- a/packages/api-client/src/index.server.ts
+++ b/packages/api-client/src/index.server.ts
@@ -33,7 +33,8 @@ import handlePaymentConfirmationResponse from './api/handlePaymentConfirmationRe
 import isGuest from './api/isGuest';
 import logIn from './api/logIn';
 import logOut from './api/logOut';
-import { makeClient, createAxiosFetcher } from '@spree/storefront-api-v2-sdk';
+import { makeClient } from '@spree/storefront-api-v2-sdk';
+import { default as createAxiosFetcher } from '@spree/storefront-api-v2-sdk/dist/server/createAxiosFetcher';
 import makeOrder from './api/makeOrder';
 import registerUser from './api/registerUser';
 import removeCoupon from './api/removeCoupon';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR reverts to the old way of importing api fetchers from the dist folder due to the SDK revert PR ([#348](https://github.com/spree/spree-storefront-api-v2-js-sdk/pull/348)).

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
