### PR TITLE
feat: add homepage cms support

### DIFF
--- a/packages/api-client/src/api/getCMSPages/index.ts
+++ b/packages/api-client/src/api/getCMSPages/index.ts
@@ -1,0 +1,20 @@
+import { PagesSearchResult, ApiContext, GetContentPagesParams } from '../../types';
+import { deserializePages } from '../serializers/page';
+
+const getPageInclude = 'cms_sections';
+
+export default async function getCMSPages({ client, config }: ApiContext, { contentPageType }: GetContentPagesParams): Promise<PagesSearchResult> {
+  const response = await client.pages.list({
+    include: getPageInclude,
+    filter: {
+      type: contentPageType
+    }
+  });
+
+  if (response.isSuccess()) {
+    const { data, included } = response.success();
+    return deserializePages(data, included, config.backendUrl);
+  } else {
+    throw response.fail();
+  }
+}

--- a/packages/api-client/src/api/serializers/page.ts
+++ b/packages/api-client/src/api/serializers/page.ts
@@ -1,5 +1,7 @@
 import { JsonApiDocument } from '@spree/storefront-api-v2-sdk/types/interfaces/JsonApi';
-import { CmsSection, ContentPage } from '../../types';
+import type { PageAttr } from '@spree/storefront-api-v2-sdk/types/interfaces/Page';
+import type { RelationType } from '@spree/storefront-api-v2-sdk/types/interfaces/Relationships';
+import { CmsSection, ContentPage, PagesSearchResult } from '../../types';
 
 export const deserializeLinks = (links: string[]): string[] => {
   return links.map(link => {
@@ -53,3 +55,21 @@ export const deserializePage = (data: JsonApiDocument, included: JsonApiDocument
   cmsSections: deserializeCmsSection(included, backendUrl)
 });
 
+export const deserializePages = (data: PageAttr[], included: JsonApiDocument[], backendUrl: string): PagesSearchResult => {
+  return {
+    data: data.map(page => ({
+      id: page.id,
+      title: page.attributes.title,
+      content: page.attributes.content,
+      locale: page.attributes.locale,
+      type: page.attributes.type,
+      slug: page.attributes.slug,
+      cmsSections: deserializeCmsSection(
+        Array.isArray(page.relationships.cms_sections.data)
+          ? page.relationships.cms_sections.data.map(section => included.find(x => x.id === section.id))
+          : [included.find(x => x.id === (page.relationships.cms_sections.data as RelationType).id)]
+        , backendUrl
+      )
+    }))
+  };
+};

--- a/packages/api-client/src/api/serializers/page.ts
+++ b/packages/api-client/src/api/serializers/page.ts
@@ -25,6 +25,7 @@ export const deserializeCmsSection = (cmsSections: JsonApiDocument[], backendUrl
     title: section.attributes.content?.title,
     subtitle: section.attributes.content?.subtitle,
     buttonText: section.attributes.content?.button_text,
+    content: section.attributes.content,
     settings: section.attributes.settings,
     fit: section.attributes.fit,
     imgOneSm: backendUrl.concat(section.attributes.img_one_sm),

--- a/packages/api-client/src/index.server.ts
+++ b/packages/api-client/src/index.server.ts
@@ -15,6 +15,7 @@ import forgotPassword from './api/forgotPassword';
 import getAddresses from './api/getAddresses';
 import getAvailableCountries from './api/getAvailableCountries';
 import getCMSPage from './api/getCMSPage';
+import getCMSPages from './api/getCMSPages';
 import getCart from './api/getCart';
 import getCategory from './api/getCategory';
 import getCountryDetails from './api/getCountryDetails';
@@ -132,7 +133,8 @@ const { createApiClient } = apiClientFactory<any, any>({
     changeCurrency,
     deleteAddress,
     getMenus,
-    getCMSPage
+    getCMSPage,
+    getCMSPages
   },
   extensions: [tokenExtension]
 });

--- a/packages/api-client/src/types/page.ts
+++ b/packages/api-client/src/types/page.ts
@@ -35,3 +35,10 @@ export type ContentPage = {
 export type GetContentPageParams = {
     contentPageSlug: string;
 };
+export type GetContentPagesParams = {
+    contentPageType: string;
+};
+
+export type PagesSearchResult = {
+    data: ContentPage[];
+}

--- a/packages/composables/src/types/content.ts
+++ b/packages/composables/src/types/content.ts
@@ -4,6 +4,7 @@ export type { ContentPage };
 
 export type ContentSearchParams = {
   contentPageSlug: string;
+  contentPageType?: string;
 };
 
 export type ContentGetters = {

--- a/packages/composables/src/useContent/index.ts
+++ b/packages/composables/src/useContent/index.ts
@@ -6,7 +6,15 @@ import {
 import { ContentPage, ContentSearchParams } from '../types';
 
 const params: UseContentFactoryParams<ContentPage, ContentSearchParams> = {
-  search: async (context: Context, { contentPageSlug }) => {
+  search: async (context: Context, { contentPageSlug, contentPageType }) => {
+    if (contentPageType) {
+      const contentPages = await context.$spree.api.getCMSPages({
+        contentPageType
+      });
+
+      return contentPages.data[0];
+    }
+
     const contentPage: ContentPage = await context.$spree.api.getCMSPage({
       contentPageSlug
     });

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -1,6 +1,9 @@
 import { getRoutes } from './routes';
 import theme from './themeConfig';
 import webpack from 'webpack';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: `./../../.env.${process.env.NODE_ENV}` });
 
 export default {
   ssr: true,
@@ -185,6 +188,7 @@ export default {
     currencies: [
       { code: 'USD', label: 'Dollar' },
       { code: 'EUR', label: 'Euro' }
-    ]
+    ],
+    backendUrl: process.env.BACKEND_URL
   }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds basic support for spree homepage configuration.

I have also added a `getCMSPages` api endpoint which returns a list of pages matching the applied filter.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
