### PR TITLE
feat: add getStore function used in nuxt.config.js

### DIFF
--- a/packages/theme/getStore.ts
+++ b/packages/theme/getStore.ts
@@ -1,0 +1,58 @@
+import axios from 'axios';
+import urlJoin from 'url-join';
+
+interface StoreConfig {
+  backendUrl: string
+}
+
+/* eslint-disable camelcase */
+export interface StoreAttr {
+  type: string
+  id: string
+  attributes: {
+    name: string
+    url: string
+    meta_description: string | null
+    meta_keywords: string | null
+    seo_title: string | null
+    default_currency: string
+    supported_currencies: string
+    default_locale: string
+    supported_locales: string
+  }
+}
+interface IStore {
+  data: StoreAttr
+}
+interface Store {
+  name: string
+  url: string
+  metaDescription?: string
+  metaKeywords?: string
+  seoTitle?: string
+  defaultCurrency: string
+  supportedCurrencies: string
+  defaultLocale: string
+  supportedLocales: string
+}
+
+const apiRoute = '/api/v2/storefront/store';
+
+const deserializeStore = (apiStore: StoreAttr): Store => ({
+  name: apiStore.attributes.name,
+  url: apiStore.attributes.url,
+  metaDescription: apiStore.attributes.meta_description,
+  metaKeywords: apiStore.attributes.meta_keywords,
+  seoTitle: apiStore.attributes.seo_title,
+  defaultCurrency: apiStore.attributes.default_currency,
+  supportedCurrencies: apiStore.attributes.supported_currencies,
+  defaultLocale: apiStore.attributes.default_locale,
+  supportedLocales: apiStore.attributes.supported_locales
+});
+
+const getStore = async (config: StoreConfig): Promise<Store> => {
+  const res = await axios.get(urlJoin(config.backendUrl, apiRoute)).then((res) => res.data) as IStore;
+  return deserializeStore(res.data);
+};
+
+export default getStore;

--- a/packages/theme/getStore.ts
+++ b/packages/theme/getStore.ts
@@ -6,53 +6,52 @@ interface StoreConfig {
 }
 
 /* eslint-disable camelcase */
-export interface StoreAttr {
-  type: string
-  id: string
-  attributes: {
-    name: string
-    url: string
-    meta_description: string | null
-    meta_keywords: string | null
-    seo_title: string | null
-    default_currency: string
-    supported_currencies: string
-    default_locale: string
-    supported_locales: string
+export interface StoreResponse {
+  data: {
+    type: string
+    id: string
+    attributes: {
+      name: string
+      url: string
+      meta_description: string | null
+      meta_keywords: string | null
+      seo_title: string | null
+      default_currency: string
+      supported_currencies: string
+      default_locale: string
+      supported_locales: string
+    }
   }
-}
-interface IStore {
-  data: StoreAttr
 }
 interface Store {
   name: string
   url: string
-  metaDescription?: string
-  metaKeywords?: string
-  seoTitle?: string
   defaultCurrency: string
   supportedCurrencies: string
   defaultLocale: string
   supportedLocales: string
+  metaDescription?: string
+  metaKeywords?: string
+  seoTitle?: string
 }
 
 const apiRoute = '/api/v2/storefront/store';
 
-const deserializeStore = (apiStore: StoreAttr): Store => ({
-  name: apiStore.attributes.name,
-  url: apiStore.attributes.url,
-  metaDescription: apiStore.attributes.meta_description,
-  metaKeywords: apiStore.attributes.meta_keywords,
-  seoTitle: apiStore.attributes.seo_title,
-  defaultCurrency: apiStore.attributes.default_currency,
-  supportedCurrencies: apiStore.attributes.supported_currencies,
-  defaultLocale: apiStore.attributes.default_locale,
-  supportedLocales: apiStore.attributes.supported_locales
+const deserializeStore = ({ data: { attributes } }: StoreResponse): Store => ({
+  name: attributes.name,
+  url: attributes.url,
+  metaDescription: attributes.meta_description,
+  metaKeywords: attributes.meta_keywords,
+  seoTitle: attributes.seo_title,
+  defaultCurrency: attributes.default_currency,
+  supportedCurrencies: attributes.supported_currencies,
+  defaultLocale: attributes.default_locale,
+  supportedLocales: attributes.supported_locales
 });
 
 const getStore = async (config: StoreConfig): Promise<Store> => {
-  const res = await axios.get(urlJoin(config.backendUrl, apiRoute)).then((res) => res.data) as IStore;
-  return deserializeStore(res.data);
+  const { data } = (await axios.get(urlJoin(config.backendUrl, apiRoute))) as { data: StoreResponse };
+  return deserializeStore(data);
 };
 
 export default getStore;

--- a/packages/theme/getStore.ts
+++ b/packages/theme/getStore.ts
@@ -3,6 +3,7 @@ import urlJoin from 'url-join';
 
 interface StoreConfig {
   backendUrl: string
+  storeApiRoute: string
 }
 
 /* eslint-disable camelcase */
@@ -35,8 +36,6 @@ interface Store {
   seoTitle?: string
 }
 
-const apiRoute = '/api/v2/storefront/store';
-
 const deserializeStore = ({ data: { attributes } }: StoreResponse): Store => ({
   name: attributes.name,
   url: attributes.url,
@@ -50,7 +49,9 @@ const deserializeStore = ({ data: { attributes } }: StoreResponse): Store => ({
 });
 
 const getStore = async (config: StoreConfig): Promise<Store> => {
-  const { data } = (await axios.get(urlJoin(config.backendUrl, apiRoute))) as { data: StoreResponse };
+  const { data } = (
+    await axios.get(urlJoin(config.backendUrl, config.storeApiRoute))
+  ) as { data: StoreResponse };
   return deserializeStore(data);
 };
 

--- a/packages/theme/getStore.ts
+++ b/packages/theme/getStore.ts
@@ -49,9 +49,9 @@ const deserializeStore = ({ data: { attributes } }: StoreResponse): Store => ({
 });
 
 const getStore = async (config: StoreConfig): Promise<Store> => {
-  const { data } = (
-    await axios.get(urlJoin(config.backendUrl, config.storeApiRoute))
-  ) as { data: StoreResponse };
+  const requestUrl = urlJoin(config.backendUrl, config.storeApiRoute);
+  const { data } = await axios.get<StoreResponse>(requestUrl);
+
   return deserializeStore(data);
 };
 

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -11,12 +11,14 @@ const serverConfig = {
   port: process.env.PORT || 3000,
   host: process.env.HOST || '0.0.0.0',
   baseUrl: process.env.BASE_URL || 'http://localhost:3000',
-  backendUrl: process.env.BACKEND_URL
+  backendUrl: process.env.BACKEND_URL,
+  storeApiRoute: process.env.STORE_API_ROUTE || '/api/v2/storefront/store'
 };
 
 export default async () => {
   const store = await getStore({
-    backendUrl: serverConfig.backendUrl
+    backendUrl: serverConfig.backendUrl,
+    storeApiRoute: serverConfig.storeApiRoute
   });
 
   return {

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -3,200 +3,208 @@ import theme from './themeConfig';
 import webpack from 'webpack';
 import * as dotenv from 'dotenv';
 import urlJoin from 'url-join';
+import getStore from './getStore';
 
 dotenv.config({ path: `./../../.env.${process.env.NODE_ENV}` });
 
 const serverConfig = {
   port: process.env.PORT || 3000,
   host: process.env.HOST || '0.0.0.0',
-  baseUrl: process.env.BASE_URL || 'http://localhost:3000'
+  baseUrl: process.env.BASE_URL || 'http://localhost:3000',
+  backendUrl: process.env.BACKEND_URL
 };
 
-export default {
-  ssr: true,
-  server: {
-    port: serverConfig.port,
-    host: serverConfig.host
-  },
-  head: {
-    title: 'Vue Storefront',
-    meta: [
-      { charset: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      {
-        hid: 'description',
-        name: 'description',
-        content: process.env.npm_package_description || ''
-      }
-    ],
-    link: [
-      {
-        rel: 'icon',
-        type: 'image/x-icon',
-        href: '/favicon.ico'
-      },
-      {
-        rel: 'preconnect',
-        href: 'https://fonts.gstatic.com',
-        crossorigin: 'crossorigin'
-      },
-      {
-        rel: 'preload',
-        href: 'https://fonts.googleapis.com/css?family=Raleway:300,400,400i,500,600,700|Roboto:300,300i,400,400i,500,700&display=swap',
-        as: 'style'
-      },
-      {
-        rel: 'stylesheet',
-        href: 'https://fonts.googleapis.com/css?family=Raleway:300,400,400i,500,600,700|Roboto:300,300i,400,400i,500,700&display=swap',
-        media: 'print',
-        onload: 'this.media=\'all\'',
-        once: true
-      }
-    ]
-  },
-  loading: { color: '#fff' },
-  plugins: ['~/plugins/i18n.js'],
-  buildModules: [
-    // to core
-    '@nuxtjs/composition-api/module',
-    '@nuxt/typescript-build',
-    '@nuxtjs/google-fonts',
-    '@nuxtjs/pwa',
-    '@nuxtjs/style-resources',
-    ['@vue-storefront/spree/nuxt', {}],
-    ['@vue-storefront/nuxt', {
-      // @core-development-only-start
-      coreDevelopment: true,
-      // @core-development-only-end
-      useRawSource: {
-        dev: [
-          '@vue-storefront/spree',
-          '@vue-storefront/core'
-        ],
-        prod: [
-          '@vue-storefront/spree',
-          '@vue-storefront/core'
-        ]
-      },
-      logger: {
-        verbosity: process.env.NODE_ENV === 'development' ? 'debug' : 'error'
-      }
-    }],
-    // @core-development-only-start
-    ['@vue-storefront/nuxt-theme', {
-      generate: {
-        replace: {
-          apiClient: '@vue-storefront/spree-api',
-          composables: '@vue-storefront/spree'
+export default async () => {
+  const store = await getStore({
+    backendUrl: serverConfig.backendUrl
+  });
+
+  return {
+    ssr: true,
+    server: {
+      port: serverConfig.port,
+      host: serverConfig.host
+    },
+    head: {
+      title: store.name || 'Vue Storefront',
+      meta: [
+        { charset: 'utf-8' },
+        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+        {
+          hid: 'description',
+          name: 'description',
+          content: store.metaDescription || ''
         }
-      }
-    }]
-    // @core-development-only-end
-    /* project-only-start
-    ['@vue-storefront/nuxt-theme'],
-    project-only-end */
-  ],
-  modules: [
-    ['@vue-storefront/nuxt', {
-      i18n: {
-        useNuxtI18nModule: true
-      }
-    }],
-    ['nuxt-i18n', {
-      baseUrl: serverConfig.baseUrl
-    }],
-    'cookie-universal-nuxt',
-    'vue-scrollto/nuxt',
-    '@vue-storefront/middleware/nuxt'
-  ],
-  i18n: {
-    detectBrowserLanguage: false,
-    currency: 'USD',
-    country: 'US',
-    strategy: 'prefix_except_default',
-    langDir: 'lang/',
-    defaultLocale: 'en',
-    locales: [
-      {
-        code: 'de',
-        iso: 'de-DE',
-        label: 'German',
-        file: 'de.js'
-      },
-      {
-        code: 'en',
-        iso: 'en-US',
-        label: 'English',
-        file: 'en.js'
-      }
+      ],
+      link: [
+        {
+          rel: 'icon',
+          type: 'image/x-icon',
+          href: '/favicon.ico'
+        },
+        {
+          rel: 'preconnect',
+          href: 'https://fonts.gstatic.com',
+          crossorigin: 'crossorigin'
+        },
+        {
+          rel: 'preload',
+          href: 'https://fonts.googleapis.com/css?family=Raleway:300,400,400i,500,600,700|Roboto:300,300i,400,400i,500,700&display=swap',
+          as: 'style'
+        },
+        {
+          rel: 'stylesheet',
+          href: 'https://fonts.googleapis.com/css?family=Raleway:300,400,400i,500,600,700|Roboto:300,300i,400,400i,500,700&display=swap',
+          media: 'print',
+          onload: 'this.media=\'all\'',
+          once: true
+        }
+      ]
+    },
+    loading: { color: '#fff' },
+    plugins: ['~/plugins/i18n.js'],
+    buildModules: [
+      // to core
+      '@nuxtjs/composition-api/module',
+      '@nuxt/typescript-build',
+      '@nuxtjs/google-fonts',
+      '@nuxtjs/pwa',
+      '@nuxtjs/style-resources',
+      ['@vue-storefront/spree/nuxt', {}],
+      ['@vue-storefront/nuxt', {
+        // @core-development-only-start
+        coreDevelopment: true,
+        // @core-development-only-end
+        useRawSource: {
+          dev: [
+            '@vue-storefront/spree',
+            '@vue-storefront/core'
+          ],
+          prod: [
+            '@vue-storefront/spree',
+            '@vue-storefront/core'
+          ]
+        },
+        logger: {
+          verbosity: process.env.NODE_ENV === 'development' ? 'debug' : 'error'
+        }
+      }],
+      // @core-development-only-start
+      ['@vue-storefront/nuxt-theme', {
+        generate: {
+          replace: {
+            apiClient: '@vue-storefront/spree-api',
+            composables: '@vue-storefront/spree'
+          }
+        }
+      }]
+      // @core-development-only-end
+      /* project-only-start
+      ['@vue-storefront/nuxt-theme'],
+      project-only-end */
     ],
-    vueI18n: {
-      silentTranslationWarn: false,
-      fallbackLocale: 'en'
-    }
-  },
-  pwa: {
-    meta: {
-      theme_color: '#5ECE7B'
-    }
-  },
-  googleFonts: {
-    families: {
-      Raleway: {
-        wght: [300, 400, 500, 600, 700],
-        ital: [400]
-      },
-      Roboto: {
-        wght: [300, 400, 500, 700],
-        ital: [300, 400]
+    modules: [
+      ['@vue-storefront/nuxt', {
+        i18n: {
+          useNuxtI18nModule: true
+        }
+      }],
+      ['nuxt-i18n', {
+        baseUrl: serverConfig.baseUrl
+      }],
+      'cookie-universal-nuxt',
+      'vue-scrollto/nuxt',
+      '@vue-storefront/middleware/nuxt'
+    ],
+    i18n: {
+      detectBrowserLanguage: false,
+      currency: store.defaultCurrency,
+      country: 'US',
+      strategy: 'prefix_except_default',
+      langDir: 'lang/',
+      defaultLocale: store.defaultLocale,
+      locales: [
+        {
+          code: 'de',
+          iso: 'de-DE',
+          label: 'German',
+          file: 'de.js'
+        },
+        {
+          code: 'en',
+          iso: 'en-US',
+          label: 'English',
+          file: 'en.js'
+        }
+      ],
+      vueI18n: {
+        silentTranslationWarn: false,
+        fallbackLocale: store.defaultLocale
       }
     },
-    display: 'swap'
-  },
-  css: [
-    '~/assets/styles.scss'
-  ],
-  styleResources: {
-    scss: [
-      require.resolve('@storefront-ui/shared/styles/_helpers.scss', { paths: [process.cwd()] }),
-      '~/assets/components/*.scss'
-    ]
-  },
-  build: {
-    transpile: [
-      'vee-validate/dist/rules'
+    pwa: {
+      meta: {
+        theme_color: '#5ECE7B'
+      }
+    },
+    googleFonts: {
+      families: {
+        Raleway: {
+          wght: [300, 400, 500, 600, 700],
+          ital: [400]
+        },
+        Roboto: {
+          wght: [300, 400, 500, 700],
+          ital: [300, 400]
+        }
+      },
+      display: 'swap'
+    },
+    css: [
+      '~/assets/styles.scss'
     ],
-    plugins: [
-      new webpack.DefinePlugin({
-        'process.VERSION': JSON.stringify({
-          // eslint-disable-next-line global-require
-          version: require('./package.json').version,
-          lastCommit: process.env.LAST_COMMIT || ''
+    styleResources: {
+      scss: [
+        require.resolve('@storefront-ui/shared/styles/_helpers.scss', { paths: [process.cwd()] }),
+        '~/assets/components/*.scss'
+      ]
+    },
+    build: {
+      transpile: [
+        'vee-validate/dist/rules'
+      ],
+      plugins: [
+        new webpack.DefinePlugin({
+          'process.VERSION': JSON.stringify({
+            // eslint-disable-next-line global-require
+            version: require('./package.json').version,
+            lastCommit: process.env.LAST_COMMIT || ''
+          })
         })
-      })
-    ]
-  },
-  router: {
-    middleware: ['checkout'],
-    scrollBehavior (_to, _from, savedPosition) {
-      if (savedPosition) {
-        return savedPosition;
-      } else {
-        return { x: 0, y: 0 };
+      ]
+    },
+    router: {
+      middleware: ['checkout'],
+      scrollBehavior (_to, _from, savedPosition) {
+        if (savedPosition) {
+          return savedPosition;
+        } else {
+          return { x: 0, y: 0 };
+        }
+      },
+      extendRoutes(routes) {
+        routes.splice(0, routes.length);
+        routes.push(...getRoutes());
       }
     },
-    extendRoutes(routes) {
-      routes.splice(0, routes.length);
-      routes.push(...getRoutes());
+    publicRuntimeConfig: {
+      theme,
+      currencies: [
+        { code: 'USD', label: 'Dollar' },
+        { code: 'EUR', label: 'Euro' }
+      ],
+      backendUrl: serverConfig.backendUrl,
+      middlewareUrl: urlJoin(serverConfig.baseUrl, '/api')
     }
-  },
-  publicRuntimeConfig: {
-    theme,
-    currencies: [
-      { code: 'USD', label: 'Dollar' },
-      { code: 'EUR', label: 'Euro' }
-    ],
-    backendUrl: process.env.BACKEND_URL,
-    middlewareUrl: urlJoin(serverConfig.baseUrl, '/api')
-  }
+  };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This PR adds a helper that fetches the Spree store configuration from the api that is then being passed to the nuxt.config.js. This is done to avoid static VSF configuration as much as possible.

There are a few crucial parts of the configuration that the api response is missing data for:
```ts
{
  locales: [
    {
      code: 'de',
      iso: 'de-DE',
      label: 'German',
      file: 'de.js'
    }
  ],
  currencies: {
    { code: 'USD', label: 'Dollar' },
  },
  country: 'US',
}
```

When it comes to loading this config dynamically on each page load, the available locales for i18n module have to be defined in nuxt.config.js ([docs](https://i18n.nuxtjs.org/options-reference#locales)). The currencies and meta tags could be loaded dynamically from the app. But splitting this logic between nuxt.config and components seems a bit messy to me, besides it won't solve the problem of having to restart the vsf server.

We could put all of the store config initialisation into the nuxt.config file (as it is now) and set up a redeployment with webhooks every time the store configuration in Spree changes. Technically only rerunning `yarn start` would be enough but that is up to the hosting platform.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
visually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
